### PR TITLE
Test: ResultError활용 Test 수정

### DIFF
--- a/feature-authentication/src/test/java/com/hmoa/feature_authentication/ResultErrorTest.kt
+++ b/feature-authentication/src/test/java/com/hmoa/feature_authentication/ResultErrorTest.kt
@@ -28,15 +28,22 @@ class ExampleUnitTest {
     @Test
     @ExperimentalCoroutinesApi
     fun When_Exception_Expected_ResultError_Test() = runTest {
-        val exceptionCases = listOf<Any?>("데이터1", "데이터2", Exception("500"))
+        val exceptionCases = listOf<Any?>("data", Exception("500"))
         launch {
             flow {
-                exceptionCases.map { emit(it) }
+                exceptionCases.map {
+                    if (it is Exception) {
+                        throw it
+                    } else {
+                        emit(it)
+                    }
+                }
+
             }.asResult().collectLatest {
                 when (it) {
                     is Result.Success -> {
                         Assertions.assertEquals(Result.Success(it).data, it)
-                        println("Result.Success 상태일 때 기대값=${Result.Success(it).data}, 실제값=${it}")
+                        println("Result.Success 상태일 때 기대값=${Result.Success(it).data}, 실제값=${it.data}")
                     }
 
                     is Result.Loading -> {
@@ -45,8 +52,8 @@ class ExampleUnitTest {
                     }
 
                     is Result.Error -> {
-                        Assertions.assertNotEquals(Exception("500"), it.exception)
-                        println("Result.Error 상태일 때 기대값=${Exception("500")}, 실제값=${it.exception}")
+                        Assertions.assertNotEquals(Result.Error(it.exception), it.exception)
+                        println("Result.Error 상태일 때 기대값=${Result.Error(it.exception)}, 실제값=${it.exception}")
                     }
                 }
 


### PR DESCRIPTION
@uselessnaming 
feature-authentication모듈 테스트에서 
Result.Error로 필터링되는 포인트는 Flow 내부에서 exception을 던질 때인 것으로 확인했습니다!
어떻게 활용할지 구조를 논의해볼 수 있을 거 같아요