### PR TITLE
Core/data exception처리 일부 적용

### DIFF
--- a/core-datastore/src/main/java/com/hmoa/core_datastore/Community/CommunityDataStoreImpl.kt
+++ b/core-datastore/src/main/java/com/hmoa/core_datastore/Community/CommunityDataStoreImpl.kt
@@ -1,9 +1,7 @@
 package com.hmoa.core_datastore.Community
 
 import ResultResponse
-import com.hmoa.core_model.Category
 import com.hmoa.core_model.response.CommunityByCategoryResponseDto
-import com.hmoa.core_model.response.CommunityCommentWithLikedResponseDto
 import com.hmoa.core_model.response.CommunityDefaultResponseDto
 import com.hmoa.core_model.response.DataResponseDto
 import com.hmoa.core_network.service.CommunityService
@@ -16,11 +14,10 @@ class CommunityDataStoreImpl @Inject constructor(private val communityService: C
     CommunityDataStore {
     override suspend fun getCommunity(communityId: Int): ResultResponse<CommunityDefaultResponseDto> {
         val result = ResultResponse<CommunityDefaultResponseDto>()
-        communityService.getCommunity(communityId).suspendMapSuccess{
+        communityService.getCommunity(communityId).suspendMapSuccess {
             result.data = this
         }.suspendOnError {
-            result.errorCode = response.code()
-            result.errorMessage = response.message()
+            result.exception = Exception(this.statusCode.code.toString())
         }
         return result
     }
@@ -33,44 +30,41 @@ class CommunityDataStoreImpl @Inject constructor(private val communityService: C
         communityId: Int
     ): ResultResponse<CommunityDefaultResponseDto> {
         val result = ResultResponse<CommunityDefaultResponseDto>()
-        communityService.postCommunityUpdate(images, deleteCommunityPhotoIds, title, content, communityId).suspendMapSuccess{
-            result.data = this
-        }.suspendOnError {
-            result.errorCode = response.code()
-            result.errorMessage = response.message()
-        }
+        communityService.postCommunityUpdate(images, deleteCommunityPhotoIds, title, content, communityId)
+            .suspendMapSuccess {
+                result.data = this
+            }.suspendOnError {
+                result.exception = Exception(this.statusCode.code.toString())
+            }
         return result
     }
 
     override suspend fun deleteCommunity(communityId: Int): ResultResponse<DataResponseDto<Nothing>> {
         val result = ResultResponse<DataResponseDto<Nothing>>()
-        communityService.deleteCommunity(communityId).suspendMapSuccess{
+        communityService.deleteCommunity(communityId).suspendMapSuccess {
             result.data = this
         }.suspendOnError {
-            result.errorCode = response.code()
-            result.errorMessage = response.message()
+            result.exception = Exception(this.statusCode.code.toString())
         }
         return result
     }
 
     override suspend fun putCommunityLike(communityId: Int): ResultResponse<DataResponseDto<Nothing>> {
         val result = ResultResponse<DataResponseDto<Nothing>>()
-        communityService.putCommunityLike(communityId).suspendMapSuccess{
+        communityService.putCommunityLike(communityId).suspendMapSuccess {
             result.data = this
         }.suspendOnError {
-            result.errorCode = response.code()
-            result.errorMessage = response.message()
+            result.exception = Exception(this.statusCode.code.toString())
         }
         return result
     }
 
     override suspend fun deleteCommunityLike(communityId: Int): ResultResponse<DataResponseDto<Nothing>> {
         val result = ResultResponse<DataResponseDto<Nothing>>()
-        communityService.deleteCommunity(communityId).suspendMapSuccess{
+        communityService.deleteCommunity(communityId).suspendMapSuccess {
             result.data = this
         }.suspendOnError {
-            result.errorCode = response.code()
-            result.errorMessage = response.message()
+            result.exception = Exception(this.statusCode.code.toString())
         }
         return result
     }
@@ -80,22 +74,20 @@ class CommunityDataStoreImpl @Inject constructor(private val communityService: C
         page: Int
     ): ResultResponse<List<CommunityByCategoryResponseDto>> {
         val result = ResultResponse<List<CommunityByCategoryResponseDto>>()
-        communityService.getCommunityByCategory(category, page).suspendMapSuccess{
+        communityService.getCommunityByCategory(category, page).suspendMapSuccess {
             result.data = this
         }.suspendOnError {
-            result.errorCode = response.code()
-            result.errorMessage = response.message()
+            result.exception = Exception(this.statusCode.code.toString())
         }
         return result
     }
 
     override suspend fun getCommunitiesHome(): ResultResponse<List<CommunityByCategoryResponseDto>> {
         val result = ResultResponse<List<CommunityByCategoryResponseDto>>()
-        communityService.getCommunitiesHome().suspendMapSuccess{
+        communityService.getCommunitiesHome().suspendMapSuccess {
             result.data = this
         }.suspendOnError {
-            result.errorCode = response.code()
-            result.errorMessage = response.message()
+            result.exception = Exception(this.statusCode.code.toString())
         }
         return result
     }
@@ -107,11 +99,10 @@ class CommunityDataStoreImpl @Inject constructor(private val communityService: C
         content: String
     ): ResultResponse<CommunityDefaultResponseDto> {
         val result = ResultResponse<CommunityDefaultResponseDto>()
-        communityService.postCommunitySave(images, category, title, content).suspendMapSuccess{
+        communityService.postCommunitySave(images, category, title, content).suspendMapSuccess {
             result.data = this
         }.suspendOnError {
-            result.errorCode = response.code()
-            result.errorMessage = response.message()
+            result.exception = Exception(this.statusCode.code.toString())
         }
         return result
     }

--- a/core-datastore/src/main/java/com/hmoa/core_datastore/CommunityComment/CommunityCommentDataStoreImpl.kt
+++ b/core-datastore/src/main/java/com/hmoa/core_datastore/CommunityComment/CommunityCommentDataStoreImpl.kt
@@ -3,11 +3,9 @@ package com.hmoa.core_datastore.CommunityComment
 import ResultResponse
 import com.hmoa.core_model.request.CommunityCommentDefaultRequestDto
 import com.hmoa.core_model.response.CommunityCommentAllResponseDto
-import com.hmoa.core_model.response.CommunityCommentDefaultResponseDto
 import com.hmoa.core_model.response.CommunityCommentWithLikedResponseDto
 import com.hmoa.core_model.response.DataResponseDto
 import com.hmoa.core_network.service.CommunityCommentService
-import com.skydoves.sandwich.ApiResponse
 import com.skydoves.sandwich.suspendMapSuccess
 import com.skydoves.sandwich.suspendOnError
 import javax.inject.Inject
@@ -19,22 +17,20 @@ class CommunityCommentDataStoreImpl @Inject constructor(private val communityCom
         dto: CommunityCommentDefaultRequestDto
     ): ResultResponse<CommunityCommentWithLikedResponseDto> {
         val result = ResultResponse<CommunityCommentWithLikedResponseDto>()
-        communityCommentService.putCommunityComment(commentId, dto).suspendMapSuccess{
+        communityCommentService.putCommunityComment(commentId, dto).suspendMapSuccess {
             result.data = this
         }.suspendOnError {
-            result.errorCode = response.code()
-            result.errorMessage = response.message()
+            result.exception = Exception(this.statusCode.code.toString())
         }
         return result
     }
 
     override suspend fun deleteCommunityComment(commentId: Int): ResultResponse<DataResponseDto<Any>> {
         val result = ResultResponse<DataResponseDto<Any>>()
-        communityCommentService.deleteCommunityComment(commentId).suspendMapSuccess{
+        communityCommentService.deleteCommunityComment(commentId).suspendMapSuccess {
             result.data = this
         }.suspendOnError {
-            result.errorCode = response.code()
-            result.errorMessage = response.message()
+            result.exception = Exception(this.statusCode.code.toString())
         }
         return result
     }
@@ -42,24 +38,22 @@ class CommunityCommentDataStoreImpl @Inject constructor(private val communityCom
     override suspend fun putCommunityCommentLiked(
         commentId: Int,
         dto: CommunityCommentDefaultRequestDto
-    ): ResultResponse<DataResponseDto<Any>>  {
+    ): ResultResponse<DataResponseDto<Any>> {
         val result = ResultResponse<DataResponseDto<Any>>()
-        communityCommentService.putCommunityCommentLiked(commentId, dto).suspendMapSuccess{
+        communityCommentService.putCommunityCommentLiked(commentId, dto).suspendMapSuccess {
             result.data = this
         }.suspendOnError {
-            result.errorCode = response.code()
-            result.errorMessage = response.message()
+            result.exception = Exception(this.statusCode.code.toString())
         }
         return result
     }
 
     override suspend fun deleteCommunityCommentLiked(commentId: Int): ResultResponse<DataResponseDto<Any>> {
         val result = ResultResponse<DataResponseDto<Any>>()
-        communityCommentService.deleteCommunityCommentLiked(commentId).suspendMapSuccess{
+        communityCommentService.deleteCommunityCommentLiked(commentId).suspendMapSuccess {
             result.data = this
         }.suspendOnError {
-            result.errorCode = response.code()
-            result.errorMessage = response.message()
+            result.exception = Exception(this.statusCode.code.toString())
         }
         return result
     }
@@ -69,11 +63,10 @@ class CommunityCommentDataStoreImpl @Inject constructor(private val communityCom
         page: Int
     ): ResultResponse<CommunityCommentAllResponseDto> {
         val result = ResultResponse<CommunityCommentAllResponseDto>()
-        communityCommentService.getCommunityComments(communityId, page).suspendMapSuccess{
+        communityCommentService.getCommunityComments(communityId, page).suspendMapSuccess {
             result.data = this
         }.suspendOnError {
-            result.errorCode = response.code()
-            result.errorMessage = response.message()
+            result.exception = Exception(this.statusCode.code.toString())
         }
         return result
     }
@@ -83,11 +76,10 @@ class CommunityCommentDataStoreImpl @Inject constructor(private val communityCom
         dto: CommunityCommentDefaultRequestDto
     ): ResultResponse<CommunityCommentWithLikedResponseDto> {
         val result = ResultResponse<CommunityCommentWithLikedResponseDto>()
-        communityCommentService.postCommunityComment(communityId, dto).suspendMapSuccess{
+        communityCommentService.postCommunityComment(communityId, dto).suspendMapSuccess {
             result.data = this
         }.suspendOnError {
-            result.errorCode = response.code()
-            result.errorMessage = response.message()
+            result.exception = Exception(this.statusCode.code.toString())
         }
         return result
     }

--- a/core-datastore/src/main/java/com/hmoa/core_datastore/Main/MainDataStore.kt
+++ b/core-datastore/src/main/java/com/hmoa/core_datastore/Main/MainDataStore.kt
@@ -1,13 +1,14 @@
 package com.hmoa.core_datastore.Main
 
+import ResultResponse
 import com.hmoa.core_model.response.HomeMenuAllResponseDto
 import com.hmoa.core_model.response.HomeMenuDefaultResponseDto
 import com.hmoa.core_model.response.HomeMenuFirstResponseDto
 
 interface MainDataStore {
-    suspend fun getFirst() : HomeMenuFirstResponseDto
-    suspend fun getFirstMenu() : HomeMenuAllResponseDto
-    suspend fun getSecond() : HomeMenuDefaultResponseDto
-    suspend fun getSecondMenu() : List<HomeMenuAllResponseDto>
-    suspend fun getThirdMenu() : List<HomeMenuAllResponseDto>
+    suspend fun getFirst(): ResultResponse<HomeMenuFirstResponseDto>
+    suspend fun getFirstMenu(): ResultResponse<HomeMenuAllResponseDto>
+    suspend fun getSecond(): ResultResponse<List<HomeMenuDefaultResponseDto>>
+    suspend fun getSecondMenu(): ResultResponse<List<HomeMenuAllResponseDto>>
+    suspend fun getThirdMenu(): ResultResponse<List<HomeMenuAllResponseDto>>
 }

--- a/core-datastore/src/main/java/com/hmoa/core_datastore/Main/MainDataStoreImpl.kt
+++ b/core-datastore/src/main/java/com/hmoa/core_datastore/Main/MainDataStoreImpl.kt
@@ -1,31 +1,64 @@
 package com.hmoa.core_datastore.Main
 
+import ResultResponse
 import com.hmoa.core_model.response.HomeMenuAllResponseDto
 import com.hmoa.core_model.response.HomeMenuDefaultResponseDto
 import com.hmoa.core_model.response.HomeMenuFirstResponseDto
 import com.hmoa.core_network.service.MainService
+import com.skydoves.sandwich.suspendMapSuccess
+import com.skydoves.sandwich.suspendOnError
 import javax.inject.Inject
 
 class MainDataStoreImpl @Inject constructor(
     private val mainService: MainService
 ) : MainDataStore {
-    override suspend fun getFirst(): HomeMenuFirstResponseDto {
-        return mainService.getFirst()
+    override suspend fun getFirst(): ResultResponse<HomeMenuFirstResponseDto> {
+        val result = ResultResponse<HomeMenuFirstResponseDto>()
+        mainService.getFirst().suspendMapSuccess {
+            result.data = this
+        }.suspendOnError {
+            result.exception = Exception(this.statusCode.code.toString())
+        }
+        return result
     }
 
-    override suspend fun getFirstMenu(): HomeMenuAllResponseDto {
-        return mainService.getFirstMenu()
+    override suspend fun getFirstMenu(): ResultResponse<HomeMenuAllResponseDto> {
+        val result = ResultResponse<HomeMenuAllResponseDto>()
+        mainService.getFirstMenu().suspendMapSuccess {
+            result.data = this
+        }.suspendOnError {
+            result.exception = Exception(this.statusCode.code.toString())
+        }
+        return result
     }
 
-    override suspend fun getSecond(): HomeMenuDefaultResponseDto {
-        return mainService.getSecond()
+    override suspend fun getSecond(): ResultResponse<List<HomeMenuDefaultResponseDto>> {
+        val result = ResultResponse<List<HomeMenuDefaultResponseDto>>()
+        mainService.getSecond().suspendMapSuccess {
+            result.data = this
+        }.suspendOnError {
+            result.exception = Exception(this.statusCode.code.toString())
+        }
+        return result
     }
 
-    override suspend fun getSecondMenu(): List<HomeMenuAllResponseDto> {
-        return mainService.getSecondMenu()
+    override suspend fun getSecondMenu(): ResultResponse<List<HomeMenuAllResponseDto>> {
+        val result = ResultResponse<List<HomeMenuAllResponseDto>>()
+        mainService.getSecondMenu().suspendMapSuccess {
+            result.data = this
+        }.suspendOnError {
+            result.exception = Exception(this.statusCode.code.toString())
+        }
+        return result
     }
 
-    override suspend fun getThirdMenu(): List<HomeMenuAllResponseDto> {
-        return mainService.getThirdMenu()
+    override suspend fun getThirdMenu(): ResultResponse<List<HomeMenuAllResponseDto>> {
+        val result = ResultResponse<List<HomeMenuAllResponseDto>>()
+        mainService.getThirdMenu().suspendMapSuccess {
+            result.data = this
+        }.suspendOnError {
+            result.exception = Exception(this.statusCode.code.toString())
+        }
+        return result
     }
 }

--- a/core-datastore/src/main/java/com/hmoa/core_datastore/Member/MemberDataStoreImpl.kt
+++ b/core-datastore/src/main/java/com/hmoa/core_datastore/Member/MemberDataStoreImpl.kt
@@ -53,8 +53,7 @@ class MemberDataStoreImpl @Inject constructor(
         memberService.updateJoin(request).suspendMapSuccess {
             result.data = this
         }.suspendOnError {
-            result.errorCode = response.code()
-            result.errorMessage = response.message()
+            result.exception = Exception(this.statusCode.code.toString())
         }
         return result
     }

--- a/core-domain/src/main/java/com/hmoa/core_domain/repository/MainRepository.kt
+++ b/core-domain/src/main/java/com/hmoa/core_domain/repository/MainRepository.kt
@@ -1,13 +1,14 @@
 package com.hmoa.core_domain.repository
 
+import ResultResponse
 import com.hmoa.core_model.response.HomeMenuAllResponseDto
 import com.hmoa.core_model.response.HomeMenuDefaultResponseDto
 import com.hmoa.core_model.response.HomeMenuFirstResponseDto
 
 interface MainRepository {
-    suspend fun getFirst(): HomeMenuFirstResponseDto
-    suspend fun getFirstMenu(): HomeMenuAllResponseDto
-    suspend fun getSecond(): HomeMenuDefaultResponseDto
-    suspend fun getSecondMenu(): List<HomeMenuAllResponseDto>
-    suspend fun getThirdMenu(): List<HomeMenuAllResponseDto>
+    suspend fun getFirst(): ResultResponse<HomeMenuFirstResponseDto>
+    suspend fun getFirstMenu(): ResultResponse<HomeMenuAllResponseDto>
+    suspend fun getSecond(): ResultResponse<List<HomeMenuDefaultResponseDto>>
+    suspend fun getSecondMenu(): ResultResponse<List<HomeMenuAllResponseDto>>
+    suspend fun getThirdMenu(): ResultResponse<List<HomeMenuAllResponseDto>>
 }

--- a/core-network/src/main/java/com/hmoa/core_network/authentication/AuthAuthenticator.kt
+++ b/core-network/src/main/java/com/hmoa/core_network/authentication/AuthAuthenticator.kt
@@ -32,7 +32,6 @@ class AuthAuthenticator @Inject constructor(
             refreshTokenManager.refreshTokens(RememberedLoginRequestDto(rememberedToken))
                 .suspendOnError {
                     if (this.response.code() == 401) {
-                        //TODO("로그인 화면으로 이동")
                         isAvailableToSendNewRequest = false
                     }
                 }

--- a/core-network/src/main/java/com/hmoa/core_network/service/MainService.kt
+++ b/core-network/src/main/java/com/hmoa/core_network/service/MainService.kt
@@ -3,21 +3,22 @@ package com.hmoa.core_network.service
 import com.hmoa.core_model.response.HomeMenuAllResponseDto
 import com.hmoa.core_model.response.HomeMenuDefaultResponseDto
 import com.hmoa.core_model.response.HomeMenuFirstResponseDto
+import com.skydoves.sandwich.ApiResponse
 import retrofit2.http.GET
 
 interface MainService {
     @GET("/main/first")
-    suspend fun getFirst(): HomeMenuFirstResponseDto
+    suspend fun getFirst(): ApiResponse<HomeMenuFirstResponseDto>
 
     @GET("/main/firstMenu")
-    suspend fun getFirstMenu(): HomeMenuAllResponseDto
+    suspend fun getFirstMenu(): ApiResponse<HomeMenuAllResponseDto>
 
     @GET("/main/second")
-    suspend fun getSecond(): HomeMenuDefaultResponseDto
+    suspend fun getSecond(): ApiResponse<List<HomeMenuDefaultResponseDto>>
 
     @GET("/main/secondMenu")
-    suspend fun getSecondMenu(): List<HomeMenuAllResponseDto>
+    suspend fun getSecondMenu(): ApiResponse<List<HomeMenuAllResponseDto>>
 
     @GET("/main/thirdMenu")
-    suspend fun getThirdMenu(): List<HomeMenuAllResponseDto>
+    suspend fun getThirdMenu(): ApiResponse<List<HomeMenuAllResponseDto>>
 }

--- a/core-repository/src/main/java/com/hmoa/core_repository/MainRepositoryImpl.kt
+++ b/core-repository/src/main/java/com/hmoa/core_repository/MainRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.hmoa.core_repository
 
+import ResultResponse
 import com.hmoa.core_datastore.Main.MainDataStore
 import com.hmoa.core_model.response.HomeMenuAllResponseDto
 import com.hmoa.core_model.response.HomeMenuDefaultResponseDto
@@ -10,23 +11,23 @@ class MainRepositoryImpl @Inject constructor(
     private val mainDataStore: MainDataStore
 ) : com.hmoa.core_domain.repository.MainRepository {
 
-    override suspend fun getFirst(): HomeMenuFirstResponseDto {
+    override suspend fun getFirst(): ResultResponse<HomeMenuFirstResponseDto> {
         return mainDataStore.getFirst()
     }
 
-    override suspend fun getFirstMenu(): HomeMenuAllResponseDto {
+    override suspend fun getFirstMenu(): ResultResponse<HomeMenuAllResponseDto> {
         return mainDataStore.getFirstMenu()
     }
 
-    override suspend fun getSecond(): HomeMenuDefaultResponseDto {
+    override suspend fun getSecond(): ResultResponse<List<HomeMenuDefaultResponseDto>> {
         return mainDataStore.getSecond()
     }
 
-    override suspend fun getSecondMenu(): List<HomeMenuAllResponseDto> {
+    override suspend fun getSecondMenu(): ResultResponse<List<HomeMenuAllResponseDto>> {
         return mainDataStore.getSecondMenu()
     }
 
-    override suspend fun getThirdMenu(): List<HomeMenuAllResponseDto> {
+    override suspend fun getThirdMenu(): ResultResponse<List<HomeMenuAllResponseDto>> {
         return mainDataStore.getThirdMenu()
     }
 }

--- a/feature-community/src/main/java/com/hmoa/feature_community/ViewModel/CommunityDescViewModel.kt
+++ b/feature-community/src/main/java/com/hmoa/feature_community/ViewModel/CommunityDescViewModel.kt
@@ -12,25 +12,15 @@ import com.hmoa.core_model.request.CommunityCommentDefaultRequestDto
 import com.hmoa.core_model.response.CommunityCommentAllResponseDto
 import com.hmoa.core_model.response.CommunityDefaultResponseDto
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.FlowCollector
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class CommunityDescViewModel @Inject constructor(
-    private val communityRepository : CommunityRepository,
-    private val communityCommentRepository : CommunityCommentRepository,
-    getUserInfo : GetMyUserInfoUseCase,
+    private val communityRepository: CommunityRepository,
+    private val communityCommentRepository: CommunityCommentRepository,
+    getUserInfo: GetMyUserInfoUseCase,
 ) : ViewModel() {
 
     private val _isOpenBottomOptions = MutableStateFlow(false)
@@ -54,40 +44,38 @@ class CommunityDescViewModel @Inject constructor(
     private val _profile = MutableStateFlow<String?>(null)
     val profile get() = _profile.asStateFlow()
 
-    init{
-        viewModelScope.launch{
+    init {
+        viewModelScope.launch {
             Log.d("TAG TEST", "view model init")
             getUserInfo().asResult()
-                .map{ result ->
-                    when(result) {
-                        Result.Loading -> _profile.update{null}
+                .map { result ->
+                    when (result) {
+                        Result.Loading -> _profile.update { null }
                         is Result.Success -> {
                             _profile.update { result.data.profile }
                         }
-                        is Result.Error -> _errState.update{ result.exception.toString() }
+
+                        is Result.Error -> _errState.update { result.exception.toString() }
                     }
                 }
         }
     }
 
-    val uiState : StateFlow<CommunityDescUiState> = combine(
-        flow{
+    val uiState: StateFlow<CommunityDescUiState> = combine(
+        flow {
             val result = communityRepository.getCommunity(id.value)
-            if (result.data == null) {
-                _errState.update { "${result.errorCode} : ${result.errorMessage}"}
-                return@flow
-            }
+
             emit(result.data!!)
         }.asResult(),
-        flow{
+        flow {
             val result = communityCommentRepository.getCommunityComments(id.value, page.value)
             if (result.data == null) {
-                _errState.update { "${result.errorCode} : ${result.errorMessage}"}
+                //_errState.update { "${result.errorCode} : ${result.errorMessage}"}
                 return@flow
             }
             emit(result.data!!)
         }.asResult()
-    ){ communityResult, commentsResult ->
+    ) { communityResult, commentsResult ->
         when {
             communityResult is Result.Error || commentsResult is Result.Error -> CommunityDescUiState.Error
             communityResult is Result.Loading || commentsResult is Result.Loading -> CommunityDescUiState.Loading
@@ -105,29 +93,29 @@ class CommunityDescViewModel @Inject constructor(
     )
 
     //bottom option 상태 업데이트
-    fun updateBottomOptionsState(state : Boolean){
-        _isOpenBottomOptions.update{ state }
+    fun updateBottomOptionsState(state: Boolean) {
+        _isOpenBottomOptions.update { state }
     }
 
     //신고하기
-    fun reportCommunity(){
+    fun reportCommunity() {
         /** 신고하기 repository 추가되어서 이거 추가해야 함 */
     }
 
     //삭제
-    fun delCommunity(){
-        viewModelScope.launch{
-            try{
+    fun delCommunity() {
+        viewModelScope.launch {
+            try {
                 communityRepository.deleteCommunity(id.value)
-            } catch (e : Exception) {
-                _errState.update{ e.message.toString() }
+            } catch (e: Exception) {
+                _errState.update { e.message.toString() }
             }
         }
     }
 
     //댓글 작성
-    fun postComment(comment : String){
-        viewModelScope.launch{
+    fun postComment(comment: String) {
+        viewModelScope.launch {
             val requestDto = CommunityCommentDefaultRequestDto(
                 content = comment
             )
@@ -137,35 +125,37 @@ class CommunityDescViewModel @Inject constructor(
                     communityId = id.value,
                     dto = requestDto
                 )
-            } catch (e : Exception) {
-                _errState.update{ e.message.toString() }
+            } catch (e: Exception) {
+                _errState.update { e.message.toString() }
             }
         }
     }
 
     //id 설정
     fun setId(id: Int) {
-        _id.update{ id }
+        _id.update { id }
     }
 }
 
-sealed interface CommunityDescUiState{
+sealed interface CommunityDescUiState {
     data object Loading : CommunityDescUiState
     data class CommunityDesc(
-        val community : CommunityDefaultResponseDto,
-        val comments : CommunityCommentAllResponseDto
+        val community: CommunityDefaultResponseDto,
+        val comments: CommunityCommentAllResponseDto
     ) : CommunityDescUiState {
-        val photoList = community.communityPhotos.map{
+        val photoList = community.communityPhotos.map {
             it.photoUrl
         }
     }
+
     data object Error : CommunityDescUiState
 }
 
-sealed interface UserInfoState{
+sealed interface UserInfoState {
     data object Loading : UserInfoState
     data class User(
-        val profile : String,
+        val profile: String,
     ) : UserInfoState
+
     data object Error : UserInfoState
 }

--- a/feature-community/src/main/java/com/hmoa/feature_community/ViewModel/CommunityEditViewModel.kt
+++ b/feature-community/src/main/java/com/hmoa/feature_community/ViewModel/CommunityEditViewModel.kt
@@ -8,22 +8,14 @@ import com.hmoa.core_domain.repository.CommunityRepository
 import com.hmoa.core_model.Category
 import com.hmoa.core_model.response.CommunityPhotoDefaultResponseDto
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import java.io.File
 import javax.inject.Inject
 
 @HiltViewModel
 class CommunityEditViewModel @Inject constructor(
-    private val repository : CommunityRepository,
+    private val repository: CommunityRepository,
 ) : ViewModel() {
 
     //가져올 게시글 id
@@ -63,7 +55,7 @@ class CommunityEditViewModel @Inject constructor(
     val errState get() = _errState.asStateFlow()
 
     //ui state
-    val uiState : StateFlow<CommunityEditUiState> = combine(
+    val uiState: StateFlow<CommunityEditUiState> = combine(
         title,
         content,
         category,
@@ -76,60 +68,62 @@ class CommunityEditViewModel @Inject constructor(
     )
 
     //id 기반 데이터 받아오기
-    private fun getCommunityDescription(id : Int){
-        viewModelScope.launch{
-            flow{
+    private fun getCommunityDescription(id: Int) {
+        viewModelScope.launch {
+            flow {
                 val result = repository.getCommunity(id)
                 if (result.data == null) {
-                    _errState.update {"${result.errorCode} : ${result.errorMessage}"}
+                    //_errState.update {"${result.errorCode} : ${result.errorMessage}"}
                     return@flow
                 }
                 emit(result.data!!)
             }.asResult()
-                .map{ result ->
-                when (result) {
-                    is Result.Loading -> {
-                        _isLoading.update {false}
-                    }
-                    is Result.Error -> {
-                        _errState.update { "Error : ${result.exception}" }
-                    }
-                    is Result.Success -> {
-                        val data = result.data
-                        _title.update{ data.title }
-                        _content.update { data.content }
-                        _category.update {
-                            val category = when(it?.name) {
-                                "시향기" -> Category.시향기
-                                "추천" -> Category.추천
-                                "자유" -> Category.자유
-                                else -> {
-                                    //불가능
-                                    throw IllegalArgumentException("올바르지 않은 Category")
-                                }
-                            }
-                            category
+                .map { result ->
+                    when (result) {
+                        is Result.Loading -> {
+                            _isLoading.update { false }
                         }
-                        _pictures.update{ data.communityPhotos}
-                        _isLoading.update{true}
+
+                        is Result.Error -> {
+                            _errState.update { "Error : ${result.exception}" }
+                        }
+
+                        is Result.Success -> {
+                            val data = result.data
+                            _title.update { data.title }
+                            _content.update { data.content }
+                            _category.update {
+                                val category = when (it?.name) {
+                                    "시향기" -> Category.시향기
+                                    "추천" -> Category.추천
+                                    "자유" -> Category.자유
+                                    else -> {
+                                        //불가능
+                                        throw IllegalArgumentException("올바르지 않은 Category")
+                                    }
+                                }
+                                category
+                            }
+                            _pictures.update { data.communityPhotos }
+                            _isLoading.update { true }
+                        }
                     }
                 }
-            }
         }
     }
 
     //title update
-    fun updateTitle(title : String){
-        _title.update{ title }
+    fun updateTitle(title: String) {
+        _title.update { title }
     }
 
     //content update
-    fun updateContent(content : String) {
-        _content.update{ content }
+    fun updateContent(content: String) {
+        _content.update { content }
     }
 
     //id setting
-    fun setId(id : Int) {
+    fun setId(id: Int) {
         _id.update { id }
 
         //id 기반으로 정보를 가져옴
@@ -138,18 +132,18 @@ class CommunityEditViewModel @Inject constructor(
 
     /** 사진 추가, 게시글 수정 어케하는 지 잘 모르겠네... */
     //picture 추가
-    fun addPictures(newPicture : String){
+    fun addPictures(newPicture: String) {
         /** add pictrues 리스트에 newPicture uri 추가 */
     }
 
-    fun delPictures(delPicture : Int){
+    fun delPictures(delPicture: Int) {
         /** del pictures 리스트에 삭제할 picture의 id 추가 */
     }
 
     //게시글 수정
-    fun updateCommunity(){
-        viewModelScope.launch{
-            if (id.value != null){
+    fun updateCommunity() {
+        viewModelScope.launch {
+            if (id.value != null) {
                 repository.postCommunityUpdate(
                     images = addPictures.value,
                     title = title.value,
@@ -158,7 +152,7 @@ class CommunityEditViewModel @Inject constructor(
                     deleteCommunityPhotoIds = delPictures.value
                 )
             } else {
-                _errState.update{ "id is null" }
+                _errState.update { "id is null" }
             }
         }
     }
@@ -167,9 +161,9 @@ class CommunityEditViewModel @Inject constructor(
 sealed interface CommunityEditUiState {
     data object Loading : CommunityEditUiState
     data class Community(
-        val title : String,
-        val content : String,
-        val category : Category?,
-        val pictures : List<CommunityPhotoDefaultResponseDto>,
+        val title: String,
+        val content: String,
+        val category: Category?,
+        val pictures: List<CommunityPhotoDefaultResponseDto>,
     ) : CommunityEditUiState
 }

--- a/feature-community/src/main/java/com/hmoa/feature_community/ViewModel/CommunityMainViewModel.kt
+++ b/feature-community/src/main/java/com/hmoa/feature_community/ViewModel/CommunityMainViewModel.kt
@@ -1,7 +1,5 @@
 package com.hmoa.feature_community.ViewModel
 
-import ResultResponse
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hmoa.core_common.Result
@@ -10,21 +8,12 @@ import com.hmoa.core_domain.repository.CommunityRepository
 import com.hmoa.core_model.Category
 import com.hmoa.core_model.response.CommunityByCategoryResponseDto
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.*
 import javax.inject.Inject
 
 @HiltViewModel
 class CommunityMainViewModel @Inject constructor(
-    private val repository : CommunityRepository
+    private val repository: CommunityRepository
 ) : ViewModel() {
 
     //type 정보
@@ -38,22 +27,23 @@ class CommunityMainViewModel @Inject constructor(
     private val _errState = MutableStateFlow("")
     val errState get() = _errState.asStateFlow()
 
-    val uiState : StateFlow<CommunityMainUiState> = type.combine(page){ type, page ->
+    val uiState: StateFlow<CommunityMainUiState> = type.combine(page) { type, page ->
         val response = repository.getCommunityByCategory(type.name, page)
         if (response.data == null) {
-            _errState.update{"${response.errorCode} : ${response.errorMessage}"}
+            //_errState.update{"${response.errorCode} : ${response.errorMessage}"}
         }
         response.data
-    }.asResult().map{
+    }.asResult().map {
         when (it) {
             is Result.Loading -> CommunityMainUiState.Loading
             is Result.Success -> {
-                if (it.data == null){
+                if (it.data == null) {
                     CommunityMainUiState.Error
                 } else {
                     CommunityMainUiState.Community(it.data!!)
                 }
             }
+
             is Result.Error -> CommunityMainUiState.Error
         }
     }.stateIn(
@@ -63,13 +53,13 @@ class CommunityMainViewModel @Inject constructor(
     )
 
     //category 정보 변경
-    fun updateCategory(category : Category) {
-        _type.update {category}
+    fun updateCategory(category: Category) {
+        _type.update { category }
     }
 
     //page 정보 변경
-    fun addPage(){
-        _page.update{_page.value + 1}
+    fun addPage() {
+        _page.update { _page.value + 1 }
     }
 
 }
@@ -77,7 +67,8 @@ class CommunityMainViewModel @Inject constructor(
 sealed interface CommunityMainUiState {
     data object Loading : CommunityMainUiState
     data class Community(
-        val communities : List<CommunityByCategoryResponseDto>
+        val communities: List<CommunityByCategoryResponseDto>
     ) : CommunityMainUiState
+
     data object Error : CommunityMainUiState
 }

--- a/feature-community/src/main/java/com/hmoa/feature_community/ViewModel/CommunityPostViewModel.kt
+++ b/feature-community/src/main/java/com/hmoa/feature_community/ViewModel/CommunityPostViewModel.kt
@@ -1,6 +1,5 @@
 package com.hmoa.feature_community.ViewModel
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hmoa.core_domain.repository.CommunityRepository
@@ -15,7 +14,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class CommunityPostViewModel @Inject constructor(
-    private val repository : CommunityRepository
+    private val repository: CommunityRepository
 ) : ViewModel() {
 
     //loading 여부 (true : 완료 / false : api event 처리 중)
@@ -43,42 +42,42 @@ class CommunityPostViewModel @Inject constructor(
     val errState get() = _errState.asStateFlow()
 
     //category 설정
-    fun setCategory (newCategory : String) {
-        when(newCategory){
-            "시향기" -> _category.update{ Category.시향기 }
-            "추천" -> _category.update {Category.추천}
-            "자유" -> _category.update {Category.자유}
+    fun setCategory(newCategory: String) {
+        when (newCategory) {
+            "시향기" -> _category.update { Category.시향기 }
+            "추천" -> _category.update { Category.추천 }
+            "자유" -> _category.update { Category.자유 }
         }
     }
 
     //title update
-    fun updateTitle (title : String) {
-        _title.update{ title }
+    fun updateTitle(title: String) {
+        _title.update { title }
     }
 
     //content update
-    fun updateContent(content : String) {
-        _content.update{ content }
+    fun updateContent(content: String) {
+        _content.update { content }
     }
 
     //사진 udpate
-    fun updatePictures(newPictures : ArrayList<File>){
-        _pictures.update{ newPictures }
+    fun updatePictures(newPictures: ArrayList<File>) {
+        _pictures.update { newPictures }
     }
 
     //게시글 게시
-    fun postCommunity(){
-        viewModelScope.launch{
+    fun postCommunity() {
+        viewModelScope.launch {
             //content, title 모두 isNotEmpty일 때
-            if (content.value != ""){
-                _errState.update{"내용을 입력해주세요"}
+            if (content.value != "") {
+                _errState.update { "내용을 입력해주세요" }
             } else if (title.value != "") {
-                _errState.update {"제목을 입력해주세요"}
+                _errState.update { "제목을 입력해주세요" }
             } else {
                 val images = pictures.value.toTypedArray()
 
-                try{
-                    _isLoading.update{false}
+                try {
+                    _isLoading.update { false }
                     val result = repository.postCommunitySave(
                         images = images,
                         category = category.value.name,
@@ -86,11 +85,11 @@ class CommunityPostViewModel @Inject constructor(
                         content = content.value
                     )
                     if (result.data == null) {
-                        _errState.update{"${result.errorCode} : ${result.errorMessage}"}
+                        //_errState.update{"${result.errorCode} : ${result.errorMessage}"}
                     }
-                    _isLoading.update{true}
-                } catch (e : Exception) {
-                    _errState.update{ e.message ?: "" }
+                    _isLoading.update { true }
+                } catch (e: Exception) {
+                    _errState.update { e.message ?: "" }
                 }
             }
         }


### PR DESCRIPTION
@uselessnaming 
Datastore의 예전 error처리 구문을 대면회의에서 작성했던 exception message 삽입구문으로 바꿨습니다! 
컴파일 에러로 인한 빌드오류 때문에 제 작업영역이 아닌 부분이지만 로직이 다 같으니까 빨리 바꿨어요!
다만 community 모듈의 viewmodel의 에러처리 부분은 컴파일에러가 났지만 고치지 않고 주석처리 했습니다!
