### PR TITLE
Feature/perfume AppViewmodel 초기 네비게이션 오류 수정

### DIFF
--- a/app/src/main/java/com/hmoa/app/AppViewModel.kt
+++ b/app/src/main/java/com/hmoa/app/AppViewModel.kt
@@ -16,12 +16,10 @@ class AppViewModel @Inject constructor(private val getAuthAndRememberedTokenUseC
     private var authToken: String? = null
     private var rememberedToken: String? = null
     suspend fun routeInitialScreen(): String {
-        viewModelScope.async {
-            val pair = getAuthAndRememberedTokenUseCase()
-            authToken = pair.first
-            rememberedToken = pair.second
-        }.await()
-
+        val pair = getAuthAndRememberedTokenUseCase()
+        authToken = pair.first
+        rememberedToken = pair.second
+        
         Log.d("TAG TEST", "token : ${authToken} / remember : ${rememberedToken}")
 
         if (authToken == null && rememberedToken == null) {

--- a/core-datastore/src/main/java/com/hmoa/core_datastore/Member/MemberDataStoreImpl.kt
+++ b/core-datastore/src/main/java/com/hmoa/core_datastore/Member/MemberDataStoreImpl.kt
@@ -1,7 +1,6 @@
 package com.hmoa.core_datastore.Member
 
 import ResultResponse
-import android.util.Log
 import com.hmoa.core_model.request.AgeRequestDto
 import com.hmoa.core_model.request.JoinUpdateRequestDto
 import com.hmoa.core_model.request.NickNameRequestDto
@@ -41,7 +40,6 @@ class MemberDataStoreImpl @Inject constructor(
 
     override suspend fun postExistsNickname(request: NickNameRequestDto): Boolean {
         var result = true
-        Log.i("postExistsNickName", "접근함")
         memberService.postExistsNickname(request).suspendOnSuccess {
             result = false
         }

--- a/core-datastore/src/main/java/com/hmoa/core_datastore/Perfume/PerfumeDataStore.kt
+++ b/core-datastore/src/main/java/com/hmoa/core_datastore/Perfume/PerfumeDataStore.kt
@@ -1,13 +1,14 @@
 package com.hmoa.core_datastore.Perfume
 
+import ResultResponse
 import com.hmoa.core_model.request.AgeRequestDto
 import com.hmoa.core_model.request.PerfumeGenderRequestDto
 import com.hmoa.core_model.request.PerfumeWeatherRequestDto
 import com.hmoa.core_model.response.*
 
 interface PerfumeDataStore {
-    suspend fun getPerfumeTopDetail(perfumeId: String): PerfumeDetailResponseDto
-    suspend fun getPerfumeBottomDetail(perfumeId: String): PerfumeDetailSecondResponseDto
+    suspend fun getPerfumeTopDetail(perfumeId: String): ResultResponse<PerfumeDetailResponseDto>
+    suspend fun getPerfumeBottomDetail(perfumeId: String): ResultResponse<PerfumeDetailSecondResponseDto>
     suspend fun postPerfumeAge(dto: AgeRequestDto, perfumeId: String): PerfumeAgeResponseDto
     suspend fun deletePerfumeAge(perfumeId: String): PerfumeAgeResponseDto
     suspend fun postPerfumeGender(dto: PerfumeGenderRequestDto, perfumeId: String): PerfumeGenderResponseDto

--- a/core-datastore/src/main/java/com/hmoa/core_datastore/Perfume/PerfumeDataStoreImpl.kt
+++ b/core-datastore/src/main/java/com/hmoa/core_datastore/Perfume/PerfumeDataStoreImpl.kt
@@ -1,19 +1,34 @@
 package com.hmoa.core_datastore.Perfume
 
+import ResultResponse
 import com.hmoa.core_model.request.AgeRequestDto
 import com.hmoa.core_model.request.PerfumeGenderRequestDto
 import com.hmoa.core_model.request.PerfumeWeatherRequestDto
 import com.hmoa.core_model.response.*
 import com.hmoa.core_network.service.PerfumeService
+import com.skydoves.sandwich.suspendOnError
+import com.skydoves.sandwich.suspendOnSuccess
 import javax.inject.Inject
 
 class PerfumeDataStoreImpl @Inject constructor(private val perfumeService: PerfumeService) : PerfumeDataStore {
-    override suspend fun getPerfumeTopDetail(perfumeId: String): PerfumeDetailResponseDto {
-        return perfumeService.getPerfumeTopDetail(perfumeId)
+    override suspend fun getPerfumeTopDetail(perfumeId: String): ResultResponse<PerfumeDetailResponseDto> {
+        var result = ResultResponse<PerfumeDetailResponseDto>()
+        perfumeService.getPerfumeTopDetail(perfumeId).suspendOnSuccess {
+            result.data = this.data
+        }.suspendOnError {
+            result.exception = Exception(this.statusCode.code.toString())
+        }
+        return result
     }
 
-    override suspend fun getPerfumeBottomDetail(perfumeId: String): PerfumeDetailSecondResponseDto {
-        return perfumeService.getPerfumeBottomDetail(perfumeId)
+    override suspend fun getPerfumeBottomDetail(perfumeId: String): ResultResponse<PerfumeDetailSecondResponseDto> {
+        var result = ResultResponse<PerfumeDetailSecondResponseDto>()
+        perfumeService.getPerfumeBottomDetail(perfumeId).suspendOnSuccess {
+            result.data = this.data
+        }.suspendOnError {
+            result.exception = Exception(this.statusCode.code.toString())
+        }
+        return result
     }
 
     override suspend fun postPerfumeAge(dto: AgeRequestDto, perfumeId: String): PerfumeAgeResponseDto {

--- a/core-network/src/main/java/com/hmoa/core_network/di/ServiceModule.kt
+++ b/core-network/src/main/java/com/hmoa/core_network/di/ServiceModule.kt
@@ -12,8 +12,8 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
@@ -56,7 +56,7 @@ object ServiceModule {
     @Provides
     fun provideHeaderInterceptor(tokenManager: TokenManager): Interceptor {
         var token: String? = null
-        CoroutineScope(Dispatchers.IO).async {
+        CoroutineScope(Dispatchers.IO).launch {
             token = tokenManager.getAuthToken().firstOrNull()
         }
 

--- a/core-network/src/main/java/com/hmoa/core_network/service/PerfumeService.kt
+++ b/core-network/src/main/java/com/hmoa/core_network/service/PerfumeService.kt
@@ -4,14 +4,15 @@ import com.hmoa.core_model.request.AgeRequestDto
 import com.hmoa.core_model.request.PerfumeGenderRequestDto
 import com.hmoa.core_model.request.PerfumeWeatherRequestDto
 import com.hmoa.core_model.response.*
+import com.skydoves.sandwich.ApiResponse
 import retrofit2.http.*
 
 interface PerfumeService {
     @GET("/perfume/{perfumeId}")
-    suspend fun getPerfumeTopDetail(@Path("perfumeId") perfumeId: String): PerfumeDetailResponseDto
+    suspend fun getPerfumeTopDetail(@Path("perfumeId") perfumeId: String): ApiResponse<PerfumeDetailResponseDto>
 
     @POST("/perfume/{perfumeId}/2")
-    suspend fun getPerfumeBottomDetail(@Path("perfumeId") perfumeId: String): PerfumeDetailSecondResponseDto
+    suspend fun getPerfumeBottomDetail(@Path("perfumeId") perfumeId: String): ApiResponse<PerfumeDetailSecondResponseDto>
 
     @POST("/perfume/{perfumeId}/age")
     suspend fun postPerfumeAge(@Body dto: AgeRequestDto, @Path("perfumeId") perfumeId: String): PerfumeAgeResponseDto

--- a/feature-perfume/src/main/java/com/hmoa/feature_perfume/viewmodel/SpecificCommentViewmodel.kt
+++ b/feature-perfume/src/main/java/com/hmoa/feature_perfume/viewmodel/SpecificCommentViewmodel.kt
@@ -2,7 +2,10 @@ package com.hmoa.feature_perfume.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.hmoa.core_common.Result
+import com.hmoa.core_common.asResult
 import com.hmoa.core_domain.repository.PerfumeCommentRepository
+import com.hmoa.core_model.request.PerfumeCommentRequestDto
 import com.hmoa.core_model.response.PerfumeCommentResponseDto
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
@@ -15,6 +18,7 @@ class SpecificCommentViewmodel @Inject constructor(
 ) : ViewModel() {
     private val perfumeCommentState = MutableStateFlow<PerfumeCommentResponseDto?>(null)
     private val likePerfumeCommentState = MutableStateFlow<Boolean>(false)
+    private val modifiedPerfumeCommentBufferState = MutableStateFlow<PerfumeCommentRequestDto?>(null)
 
     val uiState: StateFlow<SpecificCommentUiState> =
         combine(perfumeCommentState, likePerfumeCommentState) { perfumeComment, likePerfume ->
@@ -28,12 +32,32 @@ class SpecificCommentViewmodel @Inject constructor(
 
     fun initializePerfumeComment(commentId: Int) {
         viewModelScope.launch {
-            perfumeCommentState.update { perfumeCommentRepository.getPerfumeComment(commentId) }
+            flow { emit(perfumeCommentRepository.getPerfumeComment(commentId)) }.asResult().collectLatest {
+                when (it) {
+                    is com.hmoa.core_common.Result.Loading -> {
+
+                    }
+
+                    is com.hmoa.core_common.Result.Success -> {
+                        perfumeCommentState.update { it }
+                    }
+
+                    is Result.Error -> {
+
+                    }
+                }
+            }
         }
     }
 
     fun onChangeLikePerfumceCommnet() {
 
+    }
+
+    fun onChangePerfumceCommnet(text: String) {
+        viewModelScope.launch {
+            per
+        }
     }
 
     sealed interface SpecificCommentUiState {


### PR DESCRIPTION
@uselessnaming 
## 이슈#55 수정
getAuthAndRememberedTokenUseCase부분을 스코프로 감싸고 await()을 썼더니 
네비게이션에 전달되는 게 없다고 나와서 다시 변경했습니다..!
```kotlin
suspend fun routeInitialScreen(): String {
        val pair = getAuthAndRememberedTokenUseCase()
        authToken = pair.first
        rememberedToken = pair.second
        
        Log.d("TAG TEST", "token : ${authToken} / remember : ${rememberedToken}")

        if (authToken == null && rememberedToken == null) {
            return LOGIN_ROUTE
        }
        return MAIN_ROUTE
    }
```
## 앱 튕김현상 수정
계속 홈 -> 향수로 넘어갈 때 401에러가 나는 경우 튕기는 이유
-> PerfumeDataStoreImpl의 해당 메소드에서 ResultResponse<T>로 반환을 안해서 바로 Retrofit2단에서 Exception을 내고 튕기는 걸로 확인을 하게 됐습니다 ..!