### PR TITLE
Error handle 에러핸들링 추가

### DIFF
--- a/app/src/main/java/com/hmoa/app/MainActivity.kt
+++ b/app/src/main/java/com/hmoa/app/MainActivity.kt
@@ -1,6 +1,9 @@
 package com.hmoa.app
 
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
@@ -17,6 +20,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.compose.currentBackStackEntryAsState
@@ -24,6 +29,7 @@ import androidx.navigation.compose.rememberNavController
 import com.example.feature_userinfo.UserInfoGraph
 import com.example.feature_userinfo.navigateToBack
 import com.example.feature_userinfo.navigateToUserInfoGraph
+import com.google.firebase.messaging.FirebaseMessaging
 import com.hmoa.app.navigation.SetUpNavGraph
 import com.hmoa.core_designsystem.BottomScreen
 import com.hmoa.core_designsystem.component.HomeTopBar
@@ -176,41 +182,41 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun requestNotificationPermission() {
-//        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
-//            ContextCompat.checkSelfPermission(
-//                this,
-//                Manifest.permission.POST_NOTIFICATIONS
-//            ) != PackageManager.PERMISSION_GRANTED
-//        ) {
-//            ActivityCompat.requestPermissions(
-//                this,
-//                arrayOf(Manifest.permission.POST_NOTIFICATIONS),
-//                PERMISSION_REQUEST_CODE
-//            )
-//        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
+            ContextCompat.checkSelfPermission(
+                this,
+                android.Manifest.permission.POST_NOTIFICATIONS
+            ) != PackageManager.PERMISSION_GRANTED
+        ) {
+            ActivityCompat.requestPermissions(
+                this,
+                arrayOf(android.Manifest.permission.POST_NOTIFICATIONS),
+                PERMISSION_REQUEST_CODE
+            )
+        }
     }
 
     private fun checkToken() {
-//        FirebaseMessaging.getInstance().token.addOnSuccessListener {
-//            Log.d("TAG TEST", "token : ${it}")
-//        }.addOnFailureListener {
-//            Log.e("TAG TEST", "${it}")
-//        }
+        FirebaseMessaging.getInstance().token.addOnSuccessListener {
+            Log.d("TAG TEST", "token : ${it}")
+        }.addOnFailureListener {
+            Log.e("TAG TEST", "${it}")
+        }
     }
 
-//    override fun onRequestPermissionsResult(
-//        requestCode: Int,
-//        permissions: Array<out String>,
-//        grantResults: IntArray
-//    ) {
-//        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-//        if (requestCode == PERMISSION_REQUEST_CODE) {
-//
-//            if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-//                /** 권한 부여되면 처리할 작업? */
-//            } else {
-//                /** 권한 거부 시 사용자에게 설명 혹은 재요청 가능 */
-//            }
-//        }
-//    }
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray
+    ) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        if (requestCode == PERMISSION_REQUEST_CODE) {
+
+            if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                /** 권한 부여되면 처리할 작업? */
+            } else {
+                /** 권한 거부 시 사용자에게 설명 혹은 재요청 가능 */
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/hmoa/app/navigation/NavHost.kt
+++ b/app/src/main/java/com/hmoa/app/navigation/NavHost.kt
@@ -52,7 +52,8 @@ fun SetUpNavGraph(
         composable(LIKE_ROUTE) {
             LikeRoute(
                 onNavPerfumeDesc = navController::navigateToPerfume,
-                onNavHome = navController::navigateToHome
+                onNavHome = navController::navigateToHome,
+                onErrorHandleLoginAgain = navController::navigateToLogin
             )
         }
 

--- a/app/src/main/java/com/hmoa/app/navigation/NavHost.kt
+++ b/app/src/main/java/com/hmoa/app/navigation/NavHost.kt
@@ -83,7 +83,8 @@ fun SetUpNavGraph(
             onNavCommunityCommentEdit = navController::navigateToCommunityCommentEditRoute,
             onNavCommunitySearch = navController::navigateToCommunitySearchRoute,
             onNavHPediaDesc = navController::navigateToHPediaDescRoute,
-            onNavHPediaSearch = navController::navigateToHPediaSearchRoute
+            onNavHPediaSearch = navController::navigateToHPediaSearchRoute,
+            onNavLogin = navController::navigateToLogin
         )
 
         /** perfume 모듈 */

--- a/core-designsystem/src/main/java/com/hmoa/core_designsystem/component/AppDesignDialog.kt
+++ b/core-designsystem/src/main/java/com/hmoa/core_designsystem/component/AppDesignDialog.kt
@@ -33,7 +33,7 @@ fun AppDesignDialog(
 ) {
     if (isOpen) {
         Dialog(
-            onDismissRequest = onOkClick
+            onDismissRequest = onCloseClick
         ) {
             Column(
                 modifier = modifier

--- a/core-designsystem/src/main/java/com/hmoa/core_designsystem/component/FloatingActionBtn.kt
+++ b/core-designsystem/src/main/java/com/hmoa/core_designsystem/component/FloatingActionBtn.kt
@@ -2,29 +2,14 @@ package com.hmoa.core_designsystem.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -39,12 +24,13 @@ import com.hmoa.core_designsystem.R
 
 @Composable
 fun FloatingActionBtn(
-    onNavRecommend : () -> Unit,
-    onNavPresent : () -> Unit,
-    onNavFree : () -> Unit,
-){
+    onNavRecommend: () -> Unit,
+    onNavPresent: () -> Unit,
+    onNavFree: () -> Unit,
+    isAvailable: Boolean,
+) {
 
-    var isOpen by remember{mutableStateOf(false)}
+    var isOpen by remember { mutableStateOf(false) }
 
     val textStyle = TextStyle(
         color = Color.White,
@@ -59,14 +45,14 @@ fun FloatingActionBtn(
                 .fillMaxWidth()
                 .padding(end = 8.dp),
             horizontalArrangement = Arrangement.End
-        ){
+        ) {
             Icon(
                 modifier = Modifier
                     .size(56.dp)
                     .clip(CircleShape)
-                    .clickable { isOpen = !isOpen }
+                    .clickable { if (isAvailable) isOpen = !isOpen }
                     .background(color = Color.White, shape = CircleShape),
-                painter = painterResource(if(isOpen) R.drawable.ic_loading_3 else R.drawable.ic_fab),
+                painter = painterResource(if (isOpen) R.drawable.ic_loading_3 else R.drawable.ic_fab),
                 contentDescription = "FAB"
             )
         }
@@ -130,17 +116,18 @@ fun FloatingActionBtn(
 
 @Preview(showBackground = true)
 @Composable
-fun TestFAB(){
+fun TestFAB() {
     Box(
         modifier = Modifier
             .fillMaxSize()
             .background(color = Color.White),
         contentAlignment = Alignment.Center
-    ){
+    ) {
         FloatingActionBtn(
             onNavRecommend = {},
             onNavPresent = {},
-            onNavFree = {}
+            onNavFree = {},
+            isAvailable = true,
         )
     }
 }

--- a/core-designsystem/src/main/java/com/hmoa/core_designsystem/component/LoginErrorDialog.kt
+++ b/core-designsystem/src/main/java/com/hmoa/core_designsystem/component/LoginErrorDialog.kt
@@ -1,0 +1,33 @@
+package com.hmoa.core_designsystem.component
+
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun LoginErrorDialog(enableDialog: Boolean, onConfirmClick: () -> Unit, onCloseClick: () -> Unit) {
+    var isOpen by remember { mutableStateOf(true) }
+    val screenWidth = LocalConfiguration.current.screenWidthDp.dp
+
+    if (enableDialog) {
+        AppDesignDialog(
+            isOpen = isOpen,
+            modifier = Modifier.wrapContentHeight()
+                .width(screenWidth - 88.dp),
+            title = "로그인 후 이용가능한 서비스입니다",
+            content = "입력하신 내용을 다시 확인해주세요",
+            buttonTitle = "로그인 하러가기",
+            onOkClick = {
+                isOpen = false
+                onConfirmClick()
+            },
+            onCloseClick = {
+                isOpen = false
+                onCloseClick()
+            }
+        )
+    }
+}

--- a/feature-community/src/main/java/com/hmoa/feature_community/Navigation/NavGraph.kt
+++ b/feature-community/src/main/java/com/hmoa/feature_community/Navigation/NavGraph.kt
@@ -1,17 +1,10 @@
 package com.hmoa.feature_community.Navigation
 
-import android.util.Log
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
-import com.hmoa.feature_community.Screen.CommunityCommentEditRoute
-import com.hmoa.feature_community.Screen.CommunityDescriptionRoute
-import com.hmoa.feature_community.Screen.CommunityEditRoute
-import com.hmoa.feature_community.Screen.CommunityHomeRoute
-import com.hmoa.feature_community.Screen.CommunityPageRoute
-import com.hmoa.feature_community.Screen.CommunityPostRoute
-import com.hmoa.feature_community.Screen.CommunitySearchRoute
+import com.hmoa.feature_community.Screen.*
 
 //게시글 기본 화면
 fun NavController.navigateToCommunityRoute() = navigate(CommunityRoute.CommunityGraphRoute.name)
@@ -23,47 +16,53 @@ fun NavController.navigateToCommunityPage() = navigate(CommunityRoute.CommunityP
 fun NavController.navigateToCommunityHome() = navigate(CommunityRoute.CommunityHomeRoute.name)
 
 //게시글 등록 화면
-fun NavController.navigateToCommunityPostRoute(type : String) = navigate("${CommunityRoute.CommunityPostRoute.name}/${type}")
+fun NavController.navigateToCommunityPostRoute(type: String) =
+    navigate("${CommunityRoute.CommunityPostRoute.name}/${type}")
 
 //게시글 수정 화면
-fun NavController.navigateToCommunityEditRoute(id : Int) = navigate("${CommunityRoute.CommunityEditRoute.name}/${id}")
+fun NavController.navigateToCommunityEditRoute(id: Int) = navigate("${CommunityRoute.CommunityEditRoute.name}/${id}")
 
 //게시글 상세 화면
-fun NavController.navigateToCommunityDescriptionRoute(id : Int) = navigate("${CommunityRoute.CommunityDescriptionRoute.name}/${id}"){
-    popUpTo("${CommunityRoute.CommunityDescriptionRoute.name}/{id}"){inclusive = true}
-}
+fun NavController.navigateToCommunityDescriptionRoute(id: Int) =
+    navigate("${CommunityRoute.CommunityDescriptionRoute.name}/${id}") {
+        popUpTo("${CommunityRoute.CommunityDescriptionRoute.name}/{id}") { inclusive = true }
+    }
 
 //게시글 검색 화면
 fun NavController.navigateToCommunitySearchRoute() = navigate(CommunityRoute.CommunitySearchRoute.name)
 
 //댓글 수정 화면
-fun NavController.navigateToCommunityCommentEditRoute(commentId : Int) = navigate("${CommunityRoute.CommunityCommentEditRoute.name}/${commentId}")
+fun NavController.navigateToCommunityCommentEditRoute(commentId: Int) =
+    navigate("${CommunityRoute.CommunityCommentEditRoute.name}/${commentId}")
 
 fun NavGraphBuilder.nestedCommunityGraph(
-    onNavBack : () -> Unit,
-    onNavCommunityPage : () -> Unit,
-    onNavCommunityPost : (String) -> Unit,
-    onNavCommunityEdit : (Int) -> Unit,
-    onNavCommunityDescription : (Int) -> Unit,
-    onNavCommunitySearch : () -> Unit,
-    onNavCommunityCommentEdit : (Int) -> Unit
-){
+    onNavBack: () -> Unit,
+    onNavCommunityPage: () -> Unit,
+    onNavCommunityPost: (String) -> Unit,
+    onNavCommunityEdit: (Int) -> Unit,
+    onNavCommunityDescription: (Int) -> Unit,
+    onNavCommunitySearch: () -> Unit,
+    onNavCommunityCommentEdit: (Int) -> Unit,
+    onErrorHandleLoginAgain: () -> Unit,
+) {
     navigation(
         startDestination = CommunityRoute.CommunityPageRoute.name,
         route = CommunityRoute.CommunityGraphRoute.name
-    ){
+    ) {
         composable(route = CommunityRoute.CommunityHomeRoute.name) {
             CommunityHomeRoute(
                 onNavCommunityDescription = onNavCommunityDescription,
-                onNavCommunityGraph = onNavCommunityPage
+                onNavCommunityGraph = onNavCommunityPage,
+                onErrorHandleLoginAgain = onErrorHandleLoginAgain
             )
         }
-        composable(route = CommunityRoute.CommunityPageRoute.name){
+        composable(route = CommunityRoute.CommunityPageRoute.name) {
             CommunityPageRoute(
                 onNavBack = onNavBack,
                 onNavSearch = onNavCommunitySearch,
                 onNavCommunityDescription = onNavCommunityDescription,
-                onNavPost = onNavCommunityPost
+                onNavPost = onNavCommunityPost,
+                onNavLogin = onErrorHandleLoginAgain
             )
         }
         composable(route = "${CommunityRoute.CommunityPostRoute.name}/{type}") {
@@ -74,7 +73,7 @@ fun NavGraphBuilder.nestedCommunityGraph(
                 _category = type
             )
         }
-        composable(route = "${CommunityRoute.CommunityEditRoute.name}/{id}"){
+        composable(route = "${CommunityRoute.CommunityEditRoute.name}/{id}") {
             val id = it.arguments?.getString("id")
 
             CommunityEditRoute(
@@ -84,16 +83,16 @@ fun NavGraphBuilder.nestedCommunityGraph(
             )
         }
         composable(route = "${CommunityRoute.CommunityDescriptionRoute.name}/{id}") {
-            val id = it.arguments?.getString("id")?: "0"
+            val id = it.arguments?.getString("id") ?: "0"
 
-            CommunityDescriptionRoute (
+            CommunityDescriptionRoute(
                 id = id.toInt(),
                 onNavCommunityEdit = onNavCommunityEdit,
                 onNavCommentEdit = onNavCommunityCommentEdit,
                 onNavBack = onNavBack
             )
         }
-        composable(route = CommunityRoute.CommunitySearchRoute.name){
+        composable(route = CommunityRoute.CommunitySearchRoute.name) {
             CommunitySearchRoute(
                 onNavBack = onNavBack,
                 onNavCommunityDesc = onNavCommunityDescription

--- a/feature-community/src/main/java/com/hmoa/feature_community/Screen/CommunityHome.kt
+++ b/feature-community/src/main/java/com/hmoa/feature_community/Screen/CommunityHome.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -17,6 +18,8 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hmoa.component.PostListItem
+import com.hmoa.core_common.ErrorUiState
+import com.hmoa.core_designsystem.component.ErrorUiSetView
 import com.hmoa.core_designsystem.theme.CustomColor
 import com.hmoa.core_model.response.CommunityByCategoryResponseDto
 import com.hmoa.feature_community.ViewModel.CommunityHomeUiState
@@ -26,30 +29,42 @@ import com.hmoa.feature_community.ViewModel.CommunityHomeViewModel
 fun CommunityHomeRoute(
     onNavCommunityGraph: () -> Unit,
     onNavCommunityDescription: (Int) -> Unit,
+    onErrorHandleLoginAgain:()->Unit,
     viewModel: CommunityHomeViewModel = hiltViewModel(),
 ) {
 
     //ui state를 전달 >> 여기에 community list를 가지고 이를 통해 LazyColumn 이용
-    val uiState = viewModel.uiState.collectAsStateWithLifecycle()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val errorUiState by viewModel.errorUiState.collectAsStateWithLifecycle()
 
     CommunityHome(
-        uiState = uiState.value,
+        errorUiState = errorUiState,
+        uiState = uiState,
         onNavCommunityGraph = onNavCommunityGraph,
-        onNavCommunityDescription = onNavCommunityDescription
+        onNavCommunityDescription = onNavCommunityDescription,
+        onErrorHandleLoginAgain = onErrorHandleLoginAgain
     )
 }
 
 @Composable
 fun CommunityHome(
+    errorUiState: ErrorUiState,
     uiState: CommunityHomeUiState, //이거 uiState로 이전해서 uiState에서 데이터 가져오는 방식으로
     onNavCommunityGraph: () -> Unit, //카테고리 별 Community 화면으로 이동
     onNavCommunityDescription: (Int) -> Unit, //해당 Community Id를 가진 Description 화면으로 이동
+    onErrorHandleLoginAgain:()->Unit
 ) {
     Column(modifier = Modifier.padding(horizontal = 16.dp).fillMaxSize()) {
         CommunityTitleBar(onNavCommunityByCategory = onNavCommunityGraph)
+        ErrorUiSetView(
+            onConfirmClick = { onErrorHandleLoginAgain() },
+            errorUiState = errorUiState,
+            onCloseClick = {  }
+        )
+
         when (uiState) {
             is CommunityHomeUiState.Loading -> {
-                
+
             }
 
             is CommunityHomeUiState.Community -> {

--- a/feature-community/src/main/java/com/hmoa/feature_community/Screen/CommunityHome.kt
+++ b/feature-community/src/main/java/com/hmoa/feature_community/Screen/CommunityHome.kt
@@ -3,15 +3,7 @@ package com.hmoa.feature_community.Screen
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -34,12 +26,12 @@ import com.hmoa.feature_community.ViewModel.CommunityHomeViewModel
 fun CommunityHomeRoute(
     onNavCommunityGraph: () -> Unit,
     onNavCommunityDescription: (Int) -> Unit,
-    viewModel : CommunityHomeViewModel = hiltViewModel(),
-){
-    
+    viewModel: CommunityHomeViewModel = hiltViewModel(),
+) {
+
     //ui state를 전달 >> 여기에 community list를 가지고 이를 통해 LazyColumn 이용
     val uiState = viewModel.uiState.collectAsStateWithLifecycle()
-    
+
     CommunityHome(
         uiState = uiState.value,
         onNavCommunityGraph = onNavCommunityGraph,
@@ -49,79 +41,80 @@ fun CommunityHomeRoute(
 
 @Composable
 fun CommunityHome(
-    uiState : CommunityHomeUiState, //이거 uiState로 이전해서 uiState에서 데이터 가져오는 방식으로
-    onNavCommunityGraph : () -> Unit, //카테고리 별 Community 화면으로 이동
-    onNavCommunityDescription : (Int) -> Unit, //해당 Community Id를 가진 Description 화면으로 이동
-){
+    uiState: CommunityHomeUiState, //이거 uiState로 이전해서 uiState에서 데이터 가져오는 방식으로
+    onNavCommunityGraph: () -> Unit, //카테고리 별 Community 화면으로 이동
+    onNavCommunityDescription: (Int) -> Unit, //해당 Community Id를 가진 Description 화면으로 이동
+) {
+    Column(modifier = Modifier.padding(horizontal = 16.dp).fillMaxSize()) {
+        CommunityTitleBar(onNavCommunityByCategory = onNavCommunityGraph)
+        when (uiState) {
+            is CommunityHomeUiState.Loading -> {
+                
+            }
 
-    when (uiState) {
-        is CommunityHomeUiState.Loading -> {
+            is CommunityHomeUiState.Community -> {
+                CommunityHomeContent(
+                    communities = uiState.communities,
+                    onNavCommunityDescription = onNavCommunityDescription
+                )
+            }
 
-        }
-        is CommunityHomeUiState.Community -> {
-            CommunityHomeContent(
-                communities = uiState.communities,
-                onNavCommunityByCategory = onNavCommunityGraph,
-                onNavCommunityDescription = onNavCommunityDescription
-            )
-        }
-        is CommunityHomeUiState.Error -> {
+            is CommunityHomeUiState.Error -> {
 
+            }
         }
     }
+}
+
+@Composable
+fun CommunityTitleBar(
+    onNavCommunityByCategory: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.Bottom
+    ) {
+        Text(
+            text = "Community",
+            fontSize = 16.sp,
+            color = Color.Black
+        )
+
+        Text(
+            modifier = Modifier.clickable {
+                onNavCommunityByCategory()
+            },
+            text = "전체보기",
+            fontSize = 12.sp,
+            color = Color.Black
+        )
+    }
+    Spacer(Modifier.height(16.dp))
 }
 
 @Composable
 fun CommunityHomeContent(
-    communities : List<CommunityByCategoryResponseDto>,
-    onNavCommunityByCategory : () -> Unit,
-    onNavCommunityDescription : (Int) -> Unit,
-){
-    Column(
-        modifier = Modifier.fillMaxSize()
-            .padding(horizontal = 16.dp)
-    ){
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.Bottom
-        ){
-            Text(
-                text = "Community",
-                fontSize = 16.sp,
-                color = Color.Black
-            )
-
-            Text(
-                modifier = Modifier.clickable{
-                    onNavCommunityByCategory()
-                },
-                text = "전체보기",
-                fontSize = 12.sp,
-                color = Color.Black
-            )
-        }
-
-        Spacer(Modifier.height(16.dp))
-
-        PostList(
-            communities = communities,
-            onNavCommunityDescription = onNavCommunityDescription
-        )
-    }
+    communities: List<CommunityByCategoryResponseDto>,
+    onNavCommunityDescription: (Int) -> Unit,
+) {
+    PostList(
+        communities = communities,
+        onNavCommunityDescription = onNavCommunityDescription
+    )
 }
 
 @Composable
 fun PostList(
-    communities : List<CommunityByCategoryResponseDto>,
+    communities: List<CommunityByCategoryResponseDto>,
     onNavCommunityDescription: (Int) -> Unit
-){
+) {
     LazyColumn(
         modifier = Modifier.background(color = Color.White)
             .fillMaxSize(),
         verticalArrangement = Arrangement.spacedBy(8.dp)
-    ){
-        items(communities){community ->
+    ) {
+        items(communities) { community ->
             PostListItem(
                 modifier = Modifier
                     .fillMaxWidth()

--- a/feature-community/src/main/java/com/hmoa/feature_community/Screen/CommunityHome.kt
+++ b/feature-community/src/main/java/com/hmoa/feature_community/Screen/CommunityHome.kt
@@ -29,7 +29,7 @@ import com.hmoa.feature_community.ViewModel.CommunityHomeViewModel
 fun CommunityHomeRoute(
     onNavCommunityGraph: () -> Unit,
     onNavCommunityDescription: (Int) -> Unit,
-    onErrorHandleLoginAgain:()->Unit,
+    onErrorHandleLoginAgain: () -> Unit,
     viewModel: CommunityHomeViewModel = hiltViewModel(),
 ) {
 
@@ -52,14 +52,14 @@ fun CommunityHome(
     uiState: CommunityHomeUiState, //이거 uiState로 이전해서 uiState에서 데이터 가져오는 방식으로
     onNavCommunityGraph: () -> Unit, //카테고리 별 Community 화면으로 이동
     onNavCommunityDescription: (Int) -> Unit, //해당 Community Id를 가진 Description 화면으로 이동
-    onErrorHandleLoginAgain:()->Unit
+    onErrorHandleLoginAgain: () -> Unit
 ) {
     Column(modifier = Modifier.padding(horizontal = 16.dp).fillMaxSize()) {
         CommunityTitleBar(onNavCommunityByCategory = onNavCommunityGraph)
         ErrorUiSetView(
             onConfirmClick = { onErrorHandleLoginAgain() },
             errorUiState = errorUiState,
-            onCloseClick = {  }
+            onCloseClick = { }
         )
 
         when (uiState) {

--- a/feature-community/src/main/java/com/hmoa/feature_community/ViewModel/CommunityMainViewModel.kt
+++ b/feature-community/src/main/java/com/hmoa/feature_community/ViewModel/CommunityMainViewModel.kt
@@ -7,35 +7,35 @@ import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import com.hmoa.core_domain.repository.CommunityRepository
+import com.hmoa.core_domain.repository.LoginRepository
 import com.hmoa.core_model.Category
 import com.hmoa.core_model.response.CommunityByCategoryResponseDto
 import com.hmoa.feature_community.CommunityPagingSource
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 const val PAGE_SIZE = 10
 
 @HiltViewModel
 class CommunityMainViewModel @Inject constructor(
-    private val communityRepository: CommunityRepository
+    private val communityRepository: CommunityRepository,
+    private val loginRepository: LoginRepository
 ) : ViewModel() {
 
     //type 정보
     private val _type = MutableStateFlow(Category.추천)
     val type get() = _type.asStateFlow()
-
     private var _communities = MutableStateFlow<PagingData<CommunityByCategoryResponseDto>?>(null)
-
-    private val _errState = MutableStateFlow("")
-    val errState get() = _errState.asStateFlow()
-
-    val uiState : StateFlow<CommunityMainUiState> = combine(
+    val _enableLoginErrorDialog = MutableStateFlow<Boolean>(false)
+    val uiState: StateFlow<CommunityMainUiState> = combine(
         _communities,
-        type
-    ) { communities, type ->
+        _enableLoginErrorDialog
+    ) { communities, isLoginUser ->
         CommunityMainUiState.Community(
-            communities
+            communities, isLoginUser
         )
     }.stateIn(
         scope = viewModelScope,
@@ -43,7 +43,11 @@ class CommunityMainViewModel @Inject constructor(
         initialValue = CommunityMainUiState.Loading
     )
 
-    fun communityPagingSource() : Flow<PagingData<CommunityByCategoryResponseDto>> = Pager(
+    init {
+        checkIsWritingAvailable()
+    }
+
+    fun communityPagingSource(): Flow<PagingData<CommunityByCategoryResponseDto>> = Pager(
         config = PagingConfig(pageSize = PAGE_SIZE),
         pagingSourceFactory = {
             getCommunityPaging(type.value.name)
@@ -53,19 +57,32 @@ class CommunityMainViewModel @Inject constructor(
     //category 정보 변경
     fun updateCategory(category: Category) {
         _type.update { category }
-        _communities.update{ null }
+        _communities.update { null }
     }
 
-    private fun getCommunityPaging(category : String) = CommunityPagingSource(
+    private fun getCommunityPaging(category: String) = CommunityPagingSource(
         communityRepository = communityRepository,
         category = category
     )
+
+    fun checkIsWritingAvailable() {
+        viewModelScope.launch(Dispatchers.IO) {
+            loginRepository.getAuthToken().collectLatest {
+                if (it == null) {
+                    _enableLoginErrorDialog.update { true }
+                } else {
+                    _enableLoginErrorDialog.update { false }
+                }
+            }
+        }
+    }
 }
 
 sealed interface CommunityMainUiState {
     data object Loading : CommunityMainUiState
     data class Community(
-        val communities: PagingData<CommunityByCategoryResponseDto>?
+        val communities: PagingData<CommunityByCategoryResponseDto>?,
+        val enableLoginErrorDialog: Boolean
     ) : CommunityMainUiState
 
     data object Error : CommunityMainUiState

--- a/feature-hpedia/src/main/java/com/hmoa/feature_hpedia/Navigation/NavGraph.kt
+++ b/feature-hpedia/src/main/java/com/hmoa/feature_hpedia/Navigation/NavGraph.kt
@@ -1,11 +1,7 @@
 package com.hmoa.feature_hpedia.Navigation
 
-import androidx.navigation.NavController
-import androidx.navigation.NavGraphBuilder
-import androidx.navigation.NavType
+import androidx.navigation.*
 import androidx.navigation.compose.composable
-import androidx.navigation.navArgument
-import androidx.navigation.navigation
 import com.hmoa.feature_community.Navigation.nestedCommunityGraph
 import com.hmoa.feature_hpedia.Screen.HPediaDescRoute
 import com.hmoa.feature_hpedia.Screen.HPediaRoute
@@ -15,26 +11,28 @@ fun NavController.navigateToHPedia() = navigate(HPediaRoute.HPediaGraphRoute.nam
 
 fun NavController.navigateToHPediaHomeRoute() = navigate(HPediaRoute.HPedia.name)
 
-fun NavController.navigateToHPediaDescRoute(id : Int, type : String) = navigate("${HPediaRoute.HPediaDescRoute.name}/${id}/${type}")
+fun NavController.navigateToHPediaDescRoute(id: Int, type: String) =
+    navigate("${HPediaRoute.HPediaDescRoute.name}/${id}/${type}")
 
-fun NavController.navigateToHPediaSearchRoute(type : String) = navigate("${HPediaRoute.HPediaSearchRoute.name}/${type}")
+fun NavController.navigateToHPediaSearchRoute(type: String) = navigate("${HPediaRoute.HPediaSearchRoute.name}/${type}")
 
 fun NavGraphBuilder.nestedHPediaGraph(
-    onNavBack : () -> Unit,
-    onNavCommunityPage : () -> Unit,
-    onNavCommunityPost : (String) -> Unit,
-    onNavCommunityEdit : (Int) -> Unit,
-    onNavCommunityDesc : (Int) -> Unit,
-    onNavCommunityGraph : () -> Unit,
-    onNavCommunitySearch : () -> Unit,
-    onNavCommunityCommentEdit : (Int) -> Unit,
-    onNavHPediaSearch : (String) -> Unit,
-    onNavHPediaDesc : (Int, String) -> Unit,
-){
+    onNavBack: () -> Unit,
+    onNavCommunityPage: () -> Unit,
+    onNavCommunityPost: (String) -> Unit,
+    onNavCommunityEdit: (Int) -> Unit,
+    onNavCommunityDesc: (Int) -> Unit,
+    onNavCommunityGraph: () -> Unit,
+    onNavCommunitySearch: () -> Unit,
+    onNavCommunityCommentEdit: (Int) -> Unit,
+    onNavHPediaSearch: (String) -> Unit,
+    onNavHPediaDesc: (Int, String) -> Unit,
+    onNavLogin: () -> Unit,
+) {
     navigation(
         startDestination = HPediaRoute.HPedia.name,
         route = HPediaRoute.HPediaGraphRoute.name
-    ){
+    ) {
         this.nestedCommunityGraph(
             onNavBack = onNavBack,
             onNavCommunityPage = onNavCommunityPage,
@@ -42,10 +40,11 @@ fun NavGraphBuilder.nestedHPediaGraph(
             onNavCommunityEdit = onNavCommunityEdit,
             onNavCommunityDescription = onNavCommunityDesc,
             onNavCommunitySearch = onNavCommunitySearch,
-            onNavCommunityCommentEdit = onNavCommunityCommentEdit
+            onNavCommunityCommentEdit = onNavCommunityCommentEdit,
+            onErrorHandleLoginAgain = onNavLogin
         )
 
-        composable("${HPediaRoute.HPediaSearchRoute.name}/{type}"){
+        composable("${HPediaRoute.HPediaSearchRoute.name}/{type}") {
             val type = it.arguments?.getString("type")
             HPediaSearchRoute(
                 type = type,
@@ -55,12 +54,12 @@ fun NavGraphBuilder.nestedHPediaGraph(
         }
 
         composable(
-            route ="${HPediaRoute.HPediaDescRoute.name}/{id}/{type}",
+            route = "${HPediaRoute.HPediaDescRoute.name}/{id}/{type}",
             arguments = listOf(
-                navArgument("id") {type = NavType.IntType},
-                navArgument("type") {type = NavType.StringType}
+                navArgument("id") { type = NavType.IntType },
+                navArgument("type") { type = NavType.StringType }
             )
-        ){
+        ) {
 
             val id = it.arguments?.getInt("id")
             val type = it.arguments?.getString("type")
@@ -71,12 +70,13 @@ fun NavGraphBuilder.nestedHPediaGraph(
             )
         }
 
-        composable(HPediaRoute.HPedia.name){
+        composable(HPediaRoute.HPedia.name) {
             HPediaRoute(
                 onNavBack = onNavBack,
                 onNavHPediaSearch = onNavHPediaSearch,
                 onNavCommunityDesc = onNavCommunityDesc,
-                onNavCommunityGraph = onNavCommunityGraph
+                onNavCommunityGraph = onNavCommunityGraph,
+                onNavLogin = onNavLogin
             )
         }
     }

--- a/feature-hpedia/src/main/java/com/hmoa/feature_hpedia/Screen/HPediaScreen.kt
+++ b/feature-hpedia/src/main/java/com/hmoa/feature_hpedia/Screen/HPediaScreen.kt
@@ -2,16 +2,7 @@ package com.hmoa.feature_hpedia.Screen
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -26,16 +17,18 @@ import com.hmoa.feature_community.Screen.CommunityHomeRoute
 
 @Composable
 fun HPediaRoute(
-    onNavBack : () -> Unit,
-    onNavHPediaSearch : (String) -> Unit,
-    onNavCommunityDesc : (Int) -> Unit,
-    onNavCommunityGraph : () -> Unit
-){
+    onNavBack: () -> Unit,
+    onNavHPediaSearch: (String) -> Unit,
+    onNavCommunityDesc: (Int) -> Unit,
+    onNavCommunityGraph: () -> Unit,
+    onNavLogin: () -> Unit
+) {
 
     HPediaScreen(
         onNavHPediaSearch = onNavHPediaSearch,
         onNavCommunityDesc = onNavCommunityDesc,
-        onNavCommunityGraph = onNavCommunityGraph
+        onNavCommunityGraph = onNavCommunityGraph,
+        onErrorHandleLoginAgain = onNavLogin
     )
 
 }
@@ -44,18 +37,20 @@ fun HPediaRoute(
 fun HPediaScreen(
     onNavHPediaSearch: (String) -> Unit,
     onNavCommunityDesc: (Int) -> Unit,
-    onNavCommunityGraph: () -> Unit
-){
+    onNavCommunityGraph: () -> Unit,
+    onErrorHandleLoginAgain: () -> Unit,
+
+    ) {
     Column(
         modifier = Modifier
             .fillMaxSize()
             .background(color = Color.White),
-    ){
+    ) {
         Column(
             modifier = Modifier.fillMaxWidth()
                 .wrapContentHeight()
                 .padding(horizontal = 16.dp)
-        ){
+        ) {
             HPediaScreenTitle("HPedia")
             SelectSearchType(
                 onNavHPediaSearch = onNavHPediaSearch
@@ -64,29 +59,31 @@ fun HPediaScreen(
         Spacer(Modifier.height(27.dp))
         CommunityHomeRoute(
             onNavCommunityGraph = onNavCommunityGraph,
-            onNavCommunityDescription = onNavCommunityDesc
+            onNavCommunityDescription = onNavCommunityDesc,
+            onErrorHandleLoginAgain = onErrorHandleLoginAgain
         )
     }
 }
 
 @Composable
 @Preview
-fun TestHPedia(){
+fun TestHPedia() {
     HPediaScreen(
         onNavCommunityGraph = {},
         onNavCommunityDesc = {},
-        onNavHPediaSearch = {}
+        onNavHPediaSearch = {},
+        onErrorHandleLoginAgain = {}
     )
 }
 
 @Composable
-fun HPediaScreenTitle(title : String){
+fun HPediaScreenTitle(title: String) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .height(60.dp),
         verticalAlignment = Alignment.CenterVertically
-    ){
+    ) {
         Text(
             text = title,
             fontSize = 22.sp,
@@ -96,8 +93,8 @@ fun HPediaScreenTitle(title : String){
 
 @Composable
 fun SelectSearchType(
-    onNavHPediaSearch : (String) -> Unit
-){
+    onNavHPediaSearch: (String) -> Unit
+) {
     val data = listOf(
         listOf("용어", "Top notes\n탑노트란?"),
         listOf("노트", "woody\n우디"),
@@ -113,8 +110,8 @@ fun SelectSearchType(
         modifier = Modifier
             .fillMaxWidth()
             .height(140.dp)
-    ){
-        data.forEachIndexed{ idx, data ->
+    ) {
+        data.forEachIndexed { idx, data ->
             Column(
                 modifier = Modifier
                     .fillMaxHeight()
@@ -124,7 +121,7 @@ fun SelectSearchType(
                         onNavHPediaSearch(data[0])
                     }
                     .padding(16.dp)
-            ){
+            ) {
                 Text(
                     text = data[0],
                     style = textStyle
@@ -137,7 +134,7 @@ fun SelectSearchType(
                     style = textStyle
                 )
             }
-            if (idx != 2){
+            if (idx != 2) {
                 Spacer(Modifier.width(8.dp))
             }
         }

--- a/feature-perfume/src/main/java/com/hmoa/feature_perfume/screen/PerfumeScreen.kt
+++ b/feature-perfume/src/main/java/com/hmoa/feature_perfume/screen/PerfumeScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hmoa.component.TopBar
-import com.hmoa.core_common.ErrorUiState
 import com.hmoa.core_designsystem.component.*
 import com.hmoa.core_designsystem.theme.CustomColor
 import com.hmoa.core_model.PerfumeGender

--- a/feature-userInfo/src/main/java/com/hmoa/feature_userinfo/Screen/MyPage.kt
+++ b/feature-userInfo/src/main/java/com/hmoa/feature_userinfo/Screen/MyPage.kt
@@ -1,5 +1,6 @@
 package com.example.userinfo
 
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -53,7 +54,7 @@ internal fun MyPageRoute(
     val navKakao = {
         TalkApiClient.instance.chatChannel(context, BuildConfig.KAKAO_CHAT_PROFILE) { err ->
             if (err != null) {
-                viewModel.updateKakaoTalkApiClientError(err.message!!)
+                Toast.makeText(context, "향모아 챗봇 오류가 발생했습니다:(", Toast.LENGTH_LONG).show()
             }
         }
     }

--- a/feature-userInfo/src/main/java/com/hmoa/feature_userinfo/Screen/MyPage.kt
+++ b/feature-userInfo/src/main/java/com/hmoa/feature_userinfo/Screen/MyPage.kt
@@ -1,15 +1,7 @@
 package com.example.userinfo
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
@@ -19,6 +11,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -31,40 +24,46 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.feature_userinfo.viewModel.MyPageViewModel
 import com.example.feature_userinfo.viewModel.UserInfoUiState
 import com.hmoa.component.TopBar
+import com.hmoa.core_common.ErrorUiState
 import com.hmoa.core_designsystem.component.AppLoadingScreen
 import com.hmoa.core_designsystem.component.CircleImageView
+import com.hmoa.core_designsystem.component.ErrorUiSetView
 import com.hmoa.core_designsystem.component.OnAndOffBtn
 import com.hmoa.core_designsystem.theme.CustomColor
+import com.hmoa.feature_userinfo.BuildConfig
 import com.hmoa.feature_userinfo.ColumnData
 import com.hmoa.feature_userinfo.NoAuthMyPage
 import com.kakao.sdk.talk.TalkApiClient
-import com.hmoa.feature_userinfo.BuildConfig
 
 const val APP_VERSION = "1.0.0"
 
 @Composable
 internal fun MyPageRoute(
-    onNavEditProfile : () -> Unit,
-    onNavMyActivity : () -> Unit,
-    onNavManageMyInfo : () -> Unit,
-    onNavLogin : () -> Unit,
-    viewModel : MyPageViewModel = hiltViewModel()
+    onNavEditProfile: () -> Unit,
+    onNavMyActivity: () -> Unit,
+    onNavManageMyInfo: () -> Unit,
+    onNavLogin: () -> Unit,
+    onNavBack: () -> Unit,
+    viewModel: MyPageViewModel = hiltViewModel()
 ) {
     val isLogin = viewModel.isLogin.collectAsStateWithLifecycle(false)
     val uiState = viewModel.uiState.collectAsStateWithLifecycle()
+    val errorUiState by viewModel.errorUiState.collectAsStateWithLifecycle()
     val context = LocalContext.current
     val navKakao = {
         TalkApiClient.instance.chatChannel(context, BuildConfig.KAKAO_CHAT_PROFILE) { err ->
             if (err != null) {
-                viewModel.updateErr(err.message!!)
+                viewModel.updateKakaoTalkApiClientError(err.message!!)
             }
         }
     }
+
 
     if (isLogin.value) {
         //로그인 분기 처리 (토큰 확인)
         MyPage(
             uiState = uiState.value,
+            errorUiState = errorUiState,
             loginEvent = {
                 viewModel.logout()
                 onNavLogin()
@@ -77,10 +76,12 @@ internal fun MyPageRoute(
             onNavEditProfile = onNavEditProfile,
             onNavMyActivity = onNavMyActivity,
             onNavManageMyInfo = onNavManageMyInfo,
+            onErrorHandleLoginAgain = onNavLogin,
+            onBackClick = onNavBack
         )
     } else {
         //로그인 안 되어 있으면
-        NoAuthMyPage (
+        NoAuthMyPage(
             onNavLogin = onNavLogin
         )
     }
@@ -89,18 +90,22 @@ internal fun MyPageRoute(
 //인증이 되어 있는 My Page
 @Composable
 fun MyPage(
-    uiState : UserInfoUiState,
-    loginEvent : () -> Unit,
-    onDelAccount : () -> Unit,
+    uiState: UserInfoUiState,
+    errorUiState: ErrorUiState,
+    loginEvent: () -> Unit,
+    onDelAccount: () -> Unit,
     onNavKakaoChat: () -> Unit,
-    onNavEditProfile : () -> Unit,
-    onNavMyActivity : () -> Unit,
-    onNavManageMyInfo : () -> Unit,
-){
-    when(uiState){
+    onNavEditProfile: () -> Unit,
+    onNavMyActivity: () -> Unit,
+    onNavManageMyInfo: () -> Unit,
+    onErrorHandleLoginAgain: () -> Unit,
+    onBackClick: () -> Unit
+) {
+    when (uiState) {
         UserInfoUiState.Loading -> {
             AppLoadingScreen()
         }
+
         is UserInfoUiState.User -> {
             MyPageContent(
                 profile = uiState.profile,
@@ -114,33 +119,40 @@ fun MyPage(
                 onNavManageMyInfo = onNavManageMyInfo,
             )
         }
-        UserInfoUiState.Error -> {
 
+        UserInfoUiState.Error -> {
+            ErrorUiSetView(
+                onConfirmClick = { onErrorHandleLoginAgain() },
+                errorUiState = errorUiState,
+                onCloseClick = { onBackClick() }
+            )
         }
+
         else -> {}
     }
 }
+
 @Composable
 private fun MyPageContent(
-    profile : String,
-    nickname : String,
-    provider : String,
+    profile: String,
+    nickname: String,
+    provider: String,
     loginEvent: () -> Unit,
-    onDelAccount : () -> Unit,
-    onNavKakaoChat : () -> Unit,
+    onDelAccount: () -> Unit,
+    onNavKakaoChat: () -> Unit,
     onNavEditProfile: () -> Unit,
     onNavMyActivity: () -> Unit,
-    onNavManageMyInfo : () -> Unit,
-){
+    onNavManageMyInfo: () -> Unit,
+) {
     val columnInfo = listOf(
-        ColumnData("내 활동"){onNavMyActivity()},
-        ColumnData("내 정보관리"){onNavManageMyInfo()},
-        ColumnData("이용 약관"){ },
-        ColumnData("개인정보 처리방침"){  },
-        ColumnData("버전 정보 ${APP_VERSION}"){},
-        ColumnData("1대1 문의"){onNavKakaoChat()},
-        ColumnData("로그아웃"){loginEvent()},
-        ColumnData("계정삭제") {onDelAccount()},
+        ColumnData("내 활동") { onNavMyActivity() },
+        ColumnData("내 정보관리") { onNavManageMyInfo() },
+        ColumnData("이용 약관") { },
+        ColumnData("개인정보 처리방침") { },
+        ColumnData("버전 정보 ${APP_VERSION}") {},
+        ColumnData("1대1 문의") { onNavKakaoChat() },
+        ColumnData("로그아웃") { loginEvent() },
+        ColumnData("계정삭제") { onDelAccount() },
     )
 
     Column(
@@ -157,8 +169,8 @@ private fun MyPageContent(
         )
         HorizontalDivider(thickness = 1.dp, color = CustomColor.gray2)
         ServiceAlarm()
-        LazyColumn{
-            itemsIndexed(columnInfo){idx, it ->
+        LazyColumn {
+            itemsIndexed(columnInfo) { idx, it ->
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -166,10 +178,10 @@ private fun MyPageContent(
                         .padding(horizontal = 16.dp),
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.SpaceBetween
-                ){
-                    Text(text = it.title,fontSize = 16.sp)
+                ) {
+                    Text(text = it.title, fontSize = 16.sp)
 
-                    if (idx != 4){
+                    if (idx != 4) {
                         IconButton(
                             modifier = Modifier.size(20.dp),
                             onClick = it.onNavClick
@@ -183,7 +195,7 @@ private fun MyPageContent(
                         }
                     }
                 }
-                if (idx % 3 == 1){
+                if (idx % 3 == 1) {
                     HorizontalDivider(thickness = 1.dp, color = CustomColor.gray2)
                 }
             }
@@ -193,20 +205,20 @@ private fun MyPageContent(
 
 @Composable
 private fun UserProfileInfo(
-    profile : String,
-    nickname : String,
-    provider : String,
-    onNavEditProfile : () -> Unit,
-){
+    profile: String,
+    nickname: String,
+    provider: String,
+    onNavEditProfile: () -> Unit,
+) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .height(88.dp)
             .padding(horizontal = 16.dp, vertical = 22.dp),
         verticalAlignment = Alignment.CenterVertically
-    ){
+    ) {
         CircleImageView(imgUrl = profile, width = 44, height = 44)
-        Column(modifier = Modifier.weight(1f)){
+        Column(modifier = Modifier.weight(1f)) {
             //user 이름
             Text(
                 modifier = Modifier.padding(start = 12.dp),
@@ -239,7 +251,7 @@ private fun UserProfileInfo(
 @Composable
 private fun ServiceAlarm(
 
-){
+) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -247,7 +259,7 @@ private fun ServiceAlarm(
             .padding(horizontal = 16.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween
-    ){
+    ) {
         Text(
             text = "서비스 알림",
             fontSize = 16.sp

--- a/feature-userInfo/src/main/java/com/hmoa/feature_userinfo/navigation/NavGraph.kt
+++ b/feature-userInfo/src/main/java/com/hmoa/feature_userinfo/navigation/NavGraph.kt
@@ -56,7 +56,7 @@ fun NavGraphBuilder.nestedUserInfoGraph(
     onNavMyPost: () -> Unit,
     onNavMyComment: () -> Unit,
     onNavMyBirth: () -> Unit,
-    onNavMyGender: () -> Unit
+    onNavMyGender: () -> Unit,
 ) {
     navigation(
         startDestination = UserInfoGraph.MyPage.name,
@@ -67,7 +67,8 @@ fun NavGraphBuilder.nestedUserInfoGraph(
                 onNavEditProfile = onNavEditProfile,
                 onNavMyActivity = onNavMyActivity,
                 onNavManageMyInfo = onNavManageMyInfo,
-                onNavLogin = onNavLogin
+                onNavLogin = onNavLogin,
+                onNavBack = onNavBack
             )
         }
         composable(route = UserInfoGraph.EditProfileRoute.name) {
@@ -109,7 +110,7 @@ fun NavGraphBuilder.nestedUserInfoGraph(
         composable(route = UserInfoGraph.MyBirthRoute.name) {
             MyBirthRoute(onNavBack = onNavBack)
         }
-        composable(route = UserInfoGraph.MyGenderRoute.name){
+        composable(route = UserInfoGraph.MyGenderRoute.name) {
             MyGenderRoute(onNavBack = onNavBack)
         }
         composable(route = UserInfoGraph.NoAuthMyPage.name) {

--- a/feature-userInfo/src/main/java/com/hmoa/feature_userinfo/viewModel/MyPageViewModel.kt
+++ b/feature-userInfo/src/main/java/com/hmoa/feature_userinfo/viewModel/MyPageViewModel.kt
@@ -101,10 +101,6 @@ class MyPageViewModel @Inject constructor(
         }
     }
 
-    fun updateKakaoTalkApiClientError(err: String) {
-        generalErrorState.update { Pair(true, "카카오 향모아 챗봇 불러오기에 했습니다 :(") }
-    }
-
     //로그아웃
     fun logout() {
         viewModelScope.launch {

--- a/feature-userInfo/src/main/java/com/hmoa/feature_userinfo/viewModel/MyPageViewModel.kt
+++ b/feature-userInfo/src/main/java/com/hmoa/feature_userinfo/viewModel/MyPageViewModel.kt
@@ -2,6 +2,8 @@ package com.example.feature_userinfo.viewModel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.hmoa.core_common.ErrorMessageType
+import com.hmoa.core_common.ErrorUiState
 import com.hmoa.core_common.Result
 import com.hmoa.core_common.asResult
 import com.hmoa.core_domain.repository.FcmRepository
@@ -24,22 +26,38 @@ class MyPageViewModel @Inject constructor(
 
     //Login 여부
     val isLogin = authTokenState.map { it != null }
-
-    private val errState = MutableStateFlow<String?>(null)
+    private var expiredTokenErrorState = MutableStateFlow<Boolean>(false)
+    private var wrongTypeTokenErrorState = MutableStateFlow<Boolean>(false)
+    private var unLoginedErrorState = MutableStateFlow<Boolean>(false)
+    private var generalErrorState = MutableStateFlow<Pair<Boolean, String?>>(Pair(false, null))
+    val errorUiState: StateFlow<ErrorUiState> = combine(
+        expiredTokenErrorState,
+        wrongTypeTokenErrorState,
+        unLoginedErrorState,
+        generalErrorState
+    ) { expiredTokenError, wrongTypeTokenError, unknownError, generalError ->
+        ErrorUiState.ErrorData(
+            expiredTokenError = expiredTokenError,
+            wrongTypeTokenError = wrongTypeTokenError,
+            unknownError = unknownError,
+            generalError = generalError
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = ErrorUiState.Loading
+    )
 
     init {
         getAuthToken()
     }
 
-    val uiState: StateFlow<UserInfoUiState> = errState.map {
-        if (it != null) {
-            throw Exception(it)
-        }
+    val uiState: StateFlow<UserInfoUiState> = flow {
         val result = getUserInfoUseCase()
         if (result.errorMessage != null) {
             throw Exception(result.errorMessage!!.message)
         }
-        result.data!!
+        emit(result.data!!)
     }.asResult().map { result ->
         when (result) {
             Result.Loading -> UserInfoUiState.Loading
@@ -48,7 +66,26 @@ class MyPageViewModel @Inject constructor(
                 UserInfoUiState.User(data.profile, data.nickname, data.provider)
             }
 
-            is Result.Error -> UserInfoUiState.Error
+            is Result.Error -> {
+                when (result.exception.message) {
+                    ErrorMessageType.EXPIRED_TOKEN.message -> {
+                        expiredTokenErrorState.update { true }
+                    }
+
+                    ErrorMessageType.WRONG_TYPE_TOKEN.message -> {
+                        wrongTypeTokenErrorState.update { true }
+                    }
+
+                    ErrorMessageType.UNKNOWN_ERROR.message -> {
+                        unLoginedErrorState.update { true }
+                    }
+
+                    else -> {
+                        generalErrorState.update { Pair(true, result.exception.message) }
+                    }
+                }
+                UserInfoUiState.Error
+            }
         }
     }.stateIn(
         scope = viewModelScope,
@@ -64,8 +101,8 @@ class MyPageViewModel @Inject constructor(
         }
     }
 
-    fun updateErr(err: String) {
-        errState.update { err }
+    fun updateKakaoTalkApiClientError(err: String) {
+        generalErrorState.update { Pair(true, "카카오 향모아 챗봇 불러오기에 했습니다 :(") }
     }
 
     //로그아웃
@@ -83,7 +120,7 @@ class MyPageViewModel @Inject constructor(
             try {
                 memberRepository.deleteMember()
             } catch (e: Exception) {
-                errState.update { e.message }
+                generalErrorState.update { Pair(true, "계정 삭제에 실패했습니다 :(") }
             }
             loginRepository.deleteAuthToken()
             loginRepository.deleteRememberedToken()


### PR DESCRIPTION
@uselessnaming 
## 에러핸들링 UI 추가
향수페이지, Hepedia,Community,Like, MyPage 같은 큼직한 도메인의 첫화면에만 에러핸들링을 추가했습니다!
다이얼로그 기반 에러핸들링이라서 핸들링 이후의 흐름은 모두 막히기때문에 많이 추가하지 않았습니다.
그래서 MyPage의 향모아챗봇 프로필 오류는 Toast로 대체해보았습니다!
## 그외 작업
MyPage,Like  emit()누락이나 에러처리관련해서 데이터파이프라인 수정했습니다!
