### PR TITLE
HMOA-27-errorHandling fcm ApiResponse 추가 및 리팩토링

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -124,6 +124,7 @@ dependencies {
     implementation("com.google.firebase:firebase-messaging:21.1.0")
     implementation("com.google.firebase:firebase-analytics")
     implementation("com.google.android.gms:play-services-auth:21.0.0")
+    implementation("com.google.gms:google-services:4.4.1")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")

--- a/app/src/main/java/com/hmoa/app/AppViewModel.kt
+++ b/app/src/main/java/com/hmoa/app/AppViewModel.kt
@@ -25,18 +25,19 @@ class AppViewModel @Inject constructor(
     }
 
     suspend fun getFcmToken(): Flow<String?> {
-        return loginRepository.getFcmToken()
+        return fcmRepository.getLocalFcmToken()
     }
-    fun saveFcmToken(fcmToken : String){
-        viewModelScope.launch{
-            loginRepository.saveFcmToken(fcmToken)
+
+    fun saveFcmToken(fcmToken: String) {
+        viewModelScope.launch {
+            fcmRepository.saveLocalFcmToken(fcmToken)
         }
     }
 
-    fun postFcmToken(fcmToken : String){
-        viewModelScope.launch{
+    fun postFcmToken(fcmToken: String) {
+        viewModelScope.launch {
             val requestDto = FCMTokenSaveRequestDto(fcmToken)
-            fcmRepository.saveFcmToken(requestDto)
+            fcmRepository.postRemoteFcmToken(requestDto)
         }
     }
 }

--- a/core-datastore/src/main/java/com/hmoa/core_datastore/DatastoreModule.kt
+++ b/core-datastore/src/main/java/com/hmoa/core_datastore/DatastoreModule.kt
@@ -12,6 +12,8 @@ import com.hmoa.core_datastore.CommunityComment.CommunityCommentDataStore
 import com.hmoa.core_datastore.CommunityComment.CommunityCommentDataStoreImpl
 import com.hmoa.core_datastore.Fcm.FcmDataStore
 import com.hmoa.core_datastore.Fcm.FcmDataStoreImpl
+import com.hmoa.core_datastore.Fcm.FcmLocalDataStore
+import com.hmoa.core_datastore.Fcm.FcmLocalDataStoreImpl
 import com.hmoa.core_datastore.Login.LoginLocalDataStore
 import com.hmoa.core_datastore.Login.LoginLocalDataStoreImpl
 import com.hmoa.core_datastore.Login.LoginRemoteDataStore
@@ -71,6 +73,10 @@ interface DatastoreModule {
 
     @Singleton
     @Binds
+    fun provideFcmLocalDatastore(fcmLocalDataStoreImpl: FcmLocalDataStoreImpl): FcmLocalDataStore
+
+    @Singleton
+    @Binds
     fun provideLoginRemoteDatastore(loginRemoteDataStoreImpl: LoginRemoteDataStoreImpl): LoginRemoteDataStore
 
     @Singleton
@@ -115,6 +121,6 @@ interface DatastoreModule {
 
     @Singleton
     @Binds
-    fun provideTermDataStore(termDataStoreImpl: TermDataStoreImpl) : TermDataStore
+    fun provideTermDataStore(termDataStoreImpl: TermDataStoreImpl): TermDataStore
 
 }

--- a/core-datastore/src/main/java/com/hmoa/core_datastore/DatastoreModule.kt
+++ b/core-datastore/src/main/java/com/hmoa/core_datastore/DatastoreModule.kt
@@ -10,10 +10,10 @@ import com.hmoa.core_datastore.Community.CommunityDataStore
 import com.hmoa.core_datastore.Community.CommunityDataStoreImpl
 import com.hmoa.core_datastore.CommunityComment.CommunityCommentDataStore
 import com.hmoa.core_datastore.CommunityComment.CommunityCommentDataStoreImpl
-import com.hmoa.core_datastore.Fcm.FcmDataStore
-import com.hmoa.core_datastore.Fcm.FcmDataStoreImpl
 import com.hmoa.core_datastore.Fcm.FcmLocalDataStore
 import com.hmoa.core_datastore.Fcm.FcmLocalDataStoreImpl
+import com.hmoa.core_datastore.Fcm.FcmRemoteDataStore
+import com.hmoa.core_datastore.Fcm.FcmRemoteDataStoreImpl
 import com.hmoa.core_datastore.Login.LoginLocalDataStore
 import com.hmoa.core_datastore.Login.LoginLocalDataStoreImpl
 import com.hmoa.core_datastore.Login.LoginRemoteDataStore
@@ -69,7 +69,7 @@ interface DatastoreModule {
 
     @Singleton
     @Binds
-    fun provideFcmDatastore(fcmDataStoreImpl: FcmDataStoreImpl): FcmDataStore
+    fun provideFcmDatastore(fcmDataStoreImpl: FcmRemoteDataStoreImpl): FcmRemoteDataStore
 
     @Singleton
     @Binds

--- a/core-datastore/src/main/java/com/hmoa/core_datastore/Fcm/FcmDataStore.kt
+++ b/core-datastore/src/main/java/com/hmoa/core_datastore/Fcm/FcmDataStore.kt
@@ -1,12 +1,12 @@
 package com.hmoa.core_datastore.Fcm
 
+import ResultResponse
 import com.hmoa.core_model.request.FCMTokenSaveRequestDto
-import com.hmoa.core_model.response.DataResponseDto
 
 interface FcmDataStore {
 
-    suspend fun deleteFcmToken() : DataResponseDto<Any>
+    suspend fun deleteFcmToken(): ResultResponse<Any>
 
-    suspend fun saveFcmToken(fcmTokenSaveRequest : FCMTokenSaveRequestDto) : DataResponseDto<Any>
+    suspend fun saveFcmToken(fcmTokenSaveRequest: FCMTokenSaveRequestDto): ResultResponse<String>
 
 }

--- a/core-datastore/src/main/java/com/hmoa/core_datastore/Fcm/FcmDataStoreImpl.kt
+++ b/core-datastore/src/main/java/com/hmoa/core_datastore/Fcm/FcmDataStoreImpl.kt
@@ -1,19 +1,38 @@
 package com.hmoa.core_datastore.Fcm
 
+import ResultResponse
+import com.hmoa.core_model.data.ErrorMessage
 import com.hmoa.core_model.request.FCMTokenSaveRequestDto
-import com.hmoa.core_model.response.DataResponseDto
 import com.hmoa.core_network.service.FcmService
+import com.skydoves.sandwich.message
+import com.skydoves.sandwich.suspendOnError
+import com.skydoves.sandwich.suspendOnSuccess
+import kotlinx.serialization.json.Json
 import javax.inject.Inject
 
 class FcmDataStoreImpl @Inject constructor(
     private val fcmDataService: FcmService
 ) : FcmDataStore {
 
-    override suspend fun deleteFcmToken(): DataResponseDto<Any> {
-        return fcmDataService.deleteFcmToken()
+    override suspend fun deleteFcmToken(): ResultResponse<Any> {
+        var result = ResultResponse<Any>()
+        fcmDataService.deleteFcmToken().suspendOnSuccess {
+            result.data = this.data.data
+        }.suspendOnError {
+            val errorMessage = Json.decodeFromString<ErrorMessage>(this.message())
+            result.errorMessage = errorMessage
+        }
+        return result
     }
 
-    override suspend fun saveFcmToken(fcmTokenSaveRequest: FCMTokenSaveRequestDto): DataResponseDto<Any> {
-        return fcmDataService.saveFcmToken(fcmTokenSaveRequest)
+    override suspend fun saveFcmToken(fcmTokenSaveRequest: FCMTokenSaveRequestDto): ResultResponse<String> {
+        var result = ResultResponse<String>()
+        fcmDataService.saveFcmToken(fcmTokenSaveRequest).suspendOnSuccess {
+            result.data = this.data.data
+        }.suspendOnError {
+            val errorMessage = Json.decodeFromString<ErrorMessage>(this.message())
+            result.errorMessage = errorMessage
+        }
+        return result
     }
 }

--- a/core-datastore/src/main/java/com/hmoa/core_datastore/Fcm/FcmLocalDataStore.kt
+++ b/core-datastore/src/main/java/com/hmoa/core_datastore/Fcm/FcmLocalDataStore.kt
@@ -1,0 +1,9 @@
+package com.hmoa.core_datastore.Fcm
+
+import kotlinx.coroutines.flow.Flow
+
+interface FcmLocalDataStore {
+    suspend fun getLocalFcmToken(): Flow<String?>
+    suspend fun saveLocalFcmToken(token: String)
+    suspend fun deleteLocalFcmToken()
+}

--- a/core-datastore/src/main/java/com/hmoa/core_datastore/Fcm/FcmLocalDataStoreImpl.kt
+++ b/core-datastore/src/main/java/com/hmoa/core_datastore/Fcm/FcmLocalDataStoreImpl.kt
@@ -1,0 +1,21 @@
+package com.hmoa.core_datastore.Fcm
+
+import com.hmoa.core_database.TokenManager
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class FcmLocalDataStoreImpl @Inject constructor(
+    private val tokenManager: TokenManager
+) : FcmLocalDataStore {
+    override suspend fun getLocalFcmToken(): Flow<String?> {
+        return tokenManager.getFcmToken()
+    }
+
+    override suspend fun saveLocalFcmToken(token: String) {
+        tokenManager.saveFcmToken(token)
+    }
+
+    override suspend fun deleteLocalFcmToken() {
+        tokenManager.deleteFcmToken()
+    }
+}

--- a/core-datastore/src/main/java/com/hmoa/core_datastore/Fcm/FcmRemoteDataStore.kt
+++ b/core-datastore/src/main/java/com/hmoa/core_datastore/Fcm/FcmRemoteDataStore.kt
@@ -3,7 +3,7 @@ package com.hmoa.core_datastore.Fcm
 import ResultResponse
 import com.hmoa.core_model.request.FCMTokenSaveRequestDto
 
-interface FcmDataStore {
+interface FcmRemoteDataStore {
 
     suspend fun deleteFcmToken(): ResultResponse<Any>
 

--- a/core-datastore/src/main/java/com/hmoa/core_datastore/Fcm/FcmRemoteDataStoreImpl.kt
+++ b/core-datastore/src/main/java/com/hmoa/core_datastore/Fcm/FcmRemoteDataStoreImpl.kt
@@ -10,9 +10,9 @@ import com.skydoves.sandwich.suspendOnSuccess
 import kotlinx.serialization.json.Json
 import javax.inject.Inject
 
-class FcmDataStoreImpl @Inject constructor(
+class FcmRemoteDataStoreImpl @Inject constructor(
     private val fcmDataService: FcmService
-) : FcmDataStore {
+) : FcmRemoteDataStore {
 
     override suspend fun deleteFcmToken(): ResultResponse<Any> {
         var result = ResultResponse<Any>()

--- a/core-datastore/src/main/java/com/hmoa/core_datastore/Login/LoginLocalDataStore.kt
+++ b/core-datastore/src/main/java/com/hmoa/core_datastore/Login/LoginLocalDataStore.kt
@@ -7,16 +7,12 @@ interface LoginLocalDataStore {
     suspend fun getRememberedToken(): Flow<String?>
     suspend fun getKakaoAccessToken(): Flow<String?>
     suspend fun getGoogleAccessToken(): Flow<String?>
-    suspend fun getFcmToken() : Flow<String?>
-
     suspend fun saveAuthToken(token: String)
     suspend fun saveRememberedToken(token: String)
     suspend fun saveKakaoAccessToken(token: String)
     suspend fun saveGoogleAccessToken(token: String)
-    suspend fun saveFcmToken(token : String)
     suspend fun deleteAuthToken()
     suspend fun deleteRememberedToken()
     suspend fun deleteKakaoAccessToken()
     suspend fun deleteGoogleAccessToken()
-    suspend fun deleteFcmToken()
 }

--- a/core-datastore/src/main/java/com/hmoa/core_datastore/Login/LoginLocalDataStoreImpl.kt
+++ b/core-datastore/src/main/java/com/hmoa/core_datastore/Login/LoginLocalDataStoreImpl.kt
@@ -28,10 +28,6 @@ class LoginLocalDataStoreImpl @Inject constructor(
         return tokenManager.getGoogleAccessToken()
     }
 
-    override suspend fun getFcmToken(): Flow<String?> {
-        return tokenManager.getFcmToken()
-    }
-
     override suspend fun saveAuthToken(token: String) {
         Log.d("LoginLocalDataStoreImpl", "saveAuthToken:${token}")
         tokenManager.saveAuthToken(token)
@@ -50,10 +46,6 @@ class LoginLocalDataStoreImpl @Inject constructor(
         tokenManager.saveGoogleAccessToken(token)
     }
 
-    override suspend fun saveFcmToken(token: String) {
-        tokenManager.saveFcmToken(token)
-    }
-
     override suspend fun deleteAuthToken() {
         tokenManager.deleteAuthToken()
     }
@@ -68,9 +60,5 @@ class LoginLocalDataStoreImpl @Inject constructor(
 
     override suspend fun deleteGoogleAccessToken() {
         tokenManager.deleteGoogleAccessToken()
-    }
-
-    override suspend fun deleteFcmToken() {
-        tokenManager.deleteFcmToken()
     }
 }

--- a/core-domain/src/main/java/com/hmoa/core_domain/repository/FcmRepository.kt
+++ b/core-domain/src/main/java/com/hmoa/core_domain/repository/FcmRepository.kt
@@ -1,10 +1,10 @@
 package com.hmoa.core_domain.repository
 
+import ResultResponse
 import com.hmoa.core_model.request.FCMTokenSaveRequestDto
-import com.hmoa.core_model.response.DataResponseDto
 
 interface FcmRepository {
-    suspend fun deleteFcmToken(): DataResponseDto<Any>
+    suspend fun deleteFcmToken(): ResultResponse<Any>
 
-    suspend fun saveFcmToken(fcmTokenSaveRequest: FCMTokenSaveRequestDto): DataResponseDto<Any>
+    suspend fun saveFcmToken(fcmTokenSaveRequest: FCMTokenSaveRequestDto): ResultResponse<String>
 }

--- a/core-domain/src/main/java/com/hmoa/core_domain/repository/FcmRepository.kt
+++ b/core-domain/src/main/java/com/hmoa/core_domain/repository/FcmRepository.kt
@@ -2,9 +2,13 @@ package com.hmoa.core_domain.repository
 
 import ResultResponse
 import com.hmoa.core_model.request.FCMTokenSaveRequestDto
+import kotlinx.coroutines.flow.Flow
 
 interface FcmRepository {
-    suspend fun deleteFcmToken(): ResultResponse<Any>
+    suspend fun deleteRemoteFcmToken(): ResultResponse<Any>
 
-    suspend fun saveFcmToken(fcmTokenSaveRequest: FCMTokenSaveRequestDto): ResultResponse<String>
+    suspend fun postRemoteFcmToken(fcmTokenSaveRequest: FCMTokenSaveRequestDto): ResultResponse<String>
+    suspend fun getLocalFcmToken(): Flow<String?>
+    suspend fun saveLocalFcmToken(token: String)
+    suspend fun deleteLocalFcmToken()
 }

--- a/core-domain/src/main/java/com/hmoa/core_domain/repository/LoginRepository.kt
+++ b/core-domain/src/main/java/com/hmoa/core_domain/repository/LoginRepository.kt
@@ -13,17 +13,14 @@ interface LoginRepository {
     suspend fun getRememberedToken(): Flow<String?>
     suspend fun getKakaoAccessToken(): Flow<String?>
     suspend fun getGoogleAccessToken(): Flow<String?>
-    suspend fun getFcmToken(): Flow<String?>
     suspend fun postOAuth(accessToken: OauthLoginRequestDto, provider: Provider): ResultResponse<MemberLoginResponseDto>
     suspend fun postRemembered(dto: RememberedLoginRequestDto): ResultResponse<TokenResponseDto>
     suspend fun saveAuthToken(token: String)
     suspend fun saveRememberedToken(token: String)
     suspend fun saveKakaoAccessToken(token: String)
     suspend fun saveGoogleAccessToken(token: String)
-    suspend fun saveFcmToken(token : String)
     suspend fun deleteAuthToken()
     suspend fun deleteRememberedToken()
     suspend fun deleteKakaoAccessToken()
     suspend fun deleteGoogleAccessToken()
-    suspend fun deleteFcmToken()
 }

--- a/core-network/src/main/java/com/hmoa/core_network/service/FcmService.kt
+++ b/core-network/src/main/java/com/hmoa/core_network/service/FcmService.kt
@@ -2,14 +2,15 @@ package com.hmoa.core_network.service
 
 import com.hmoa.core_model.request.FCMTokenSaveRequestDto
 import com.hmoa.core_model.response.DataResponseDto
+import com.skydoves.sandwich.ApiResponse
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.POST
 
 interface FcmService {
     @DELETE("/fcm/delete")
-    suspend fun deleteFcmToken(): DataResponseDto<Any>
+    suspend fun deleteFcmToken(): ApiResponse<DataResponseDto<Any>>
 
     @POST("/fcm/save")
-    suspend fun saveFcmToken(@Body fcmTokenSaveRequest: FCMTokenSaveRequestDto): DataResponseDto<Any>
+    suspend fun saveFcmToken(@Body fcmTokenSaveRequest: FCMTokenSaveRequestDto): ApiResponse<DataResponseDto<String>>
 }

--- a/core-repository/src/main/java/com/hmoa/core_repository/FcmRepositoryImpl.kt
+++ b/core-repository/src/main/java/com/hmoa/core_repository/FcmRepositoryImpl.kt
@@ -1,14 +1,14 @@
 package com.hmoa.core_repository
 
 import ResultResponse
-import com.hmoa.core_datastore.Fcm.FcmDataStore
 import com.hmoa.core_datastore.Fcm.FcmLocalDataStore
+import com.hmoa.core_datastore.Fcm.FcmRemoteDataStore
 import com.hmoa.core_model.request.FCMTokenSaveRequestDto
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class FcmRepositoryImpl @Inject constructor(
-    private val fcmDataStore: FcmDataStore,
+    private val fcmDataStore: FcmRemoteDataStore,
     private val fcmLocalDataStore: FcmLocalDataStore
 ) :
     com.hmoa.core_domain.repository.FcmRepository {

--- a/core-repository/src/main/java/com/hmoa/core_repository/FcmRepositoryImpl.kt
+++ b/core-repository/src/main/java/com/hmoa/core_repository/FcmRepositoryImpl.kt
@@ -2,17 +2,34 @@ package com.hmoa.core_repository
 
 import ResultResponse
 import com.hmoa.core_datastore.Fcm.FcmDataStore
+import com.hmoa.core_datastore.Fcm.FcmLocalDataStore
 import com.hmoa.core_model.request.FCMTokenSaveRequestDto
+import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
-class FcmRepositoryImpl @Inject constructor(private val fcmDataStore: FcmDataStore) :
+class FcmRepositoryImpl @Inject constructor(
+    private val fcmDataStore: FcmDataStore,
+    private val fcmLocalDataStore: FcmLocalDataStore
+) :
     com.hmoa.core_domain.repository.FcmRepository {
 
-    override suspend fun deleteFcmToken(): ResultResponse<Any> {
+    override suspend fun deleteRemoteFcmToken(): ResultResponse<Any> {
         return fcmDataStore.deleteFcmToken()
     }
 
-    override suspend fun saveFcmToken(fcmTokenSaveRequest: FCMTokenSaveRequestDto): ResultResponse<String> {
+    override suspend fun postRemoteFcmToken(fcmTokenSaveRequest: FCMTokenSaveRequestDto): ResultResponse<String> {
         return fcmDataStore.saveFcmToken(fcmTokenSaveRequest)
+    }
+
+    override suspend fun getLocalFcmToken(): Flow<String?> {
+        return fcmLocalDataStore.getLocalFcmToken()
+    }
+
+    override suspend fun saveLocalFcmToken(token: String) {
+        fcmLocalDataStore.saveLocalFcmToken(token)
+    }
+
+    override suspend fun deleteLocalFcmToken() {
+        fcmLocalDataStore.deleteLocalFcmToken()
     }
 }

--- a/core-repository/src/main/java/com/hmoa/core_repository/FcmRepositoryImpl.kt
+++ b/core-repository/src/main/java/com/hmoa/core_repository/FcmRepositoryImpl.kt
@@ -1,18 +1,18 @@
 package com.hmoa.core_repository
 
+import ResultResponse
 import com.hmoa.core_datastore.Fcm.FcmDataStore
 import com.hmoa.core_model.request.FCMTokenSaveRequestDto
-import com.hmoa.core_model.response.DataResponseDto
 import javax.inject.Inject
 
 class FcmRepositoryImpl @Inject constructor(private val fcmDataStore: FcmDataStore) :
     com.hmoa.core_domain.repository.FcmRepository {
 
-    override suspend fun deleteFcmToken(): DataResponseDto<Any> {
+    override suspend fun deleteFcmToken(): ResultResponse<Any> {
         return fcmDataStore.deleteFcmToken()
     }
 
-    override suspend fun saveFcmToken(fcmTokenSaveRequest: FCMTokenSaveRequestDto): DataResponseDto<Any> {
+    override suspend fun saveFcmToken(fcmTokenSaveRequest: FCMTokenSaveRequestDto): ResultResponse<String> {
         return fcmDataStore.saveFcmToken(fcmTokenSaveRequest)
     }
 }

--- a/core-repository/src/main/java/com/hmoa/core_repository/LoginRepositoryImpl.kt
+++ b/core-repository/src/main/java/com/hmoa/core_repository/LoginRepositoryImpl.kt
@@ -36,10 +36,6 @@ class LoginRepositoryImpl @Inject constructor(
         return loginLocalDataStore.getGoogleAccessToken()
     }
 
-    override suspend fun getFcmToken(): Flow<String?> {
-        return loginLocalDataStore.getFcmToken()
-    }
-
     override suspend fun postOAuth(
         accessToken: OauthLoginRequestDto,
         provider: Provider
@@ -69,9 +65,6 @@ class LoginRepositoryImpl @Inject constructor(
         loginLocalDataStore.saveGoogleAccessToken(token)
     }
 
-    override suspend fun saveFcmToken(token: String) {
-        loginLocalDataStore.saveFcmToken(token)
-    }
     override suspend fun deleteAuthToken() {
         loginLocalDataStore.deleteAuthToken()
     }
@@ -86,9 +79,5 @@ class LoginRepositoryImpl @Inject constructor(
 
     override suspend fun deleteGoogleAccessToken() {
         loginLocalDataStore.deleteGoogleAccessToken()
-    }
-
-    override suspend fun deleteFcmToken() {
-        loginLocalDataStore.deleteFcmToken()
     }
 }

--- a/feature-authentication/build.gradle.kts
+++ b/feature-authentication/build.gradle.kts
@@ -94,7 +94,7 @@ dependencies {
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
     //goole-login
     implementation("com.google.android.gms:play-services-auth:21.0.0")
-
+    implementation("com.google.gms:google-services:4.4.1")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
     testImplementation("junit:junit:4.13.2")

--- a/feature-authentication/src/main/java/com/hmoa/feature_authentication/LoginScreen.kt
+++ b/feature-authentication/src/main/java/com/hmoa/feature_authentication/LoginScreen.kt
@@ -6,12 +6,7 @@ import android.content.ContextWrapper
 import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
@@ -54,9 +49,10 @@ fun requestGoogleLogin(context: Context): GoogleSignInClient {
         "feature-authentication",
         "requestGoogleLogin, clientId: ${clientId}"
     )
-    val googleSignInOption = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
-        .requestServerAuthCode(clientId) // string 파일에 저장해둔 client id 를 이용해 server authcode를 요청한다.
-        .build()
+    val googleSignInOption =
+        GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+            .build()
+
     Log.d("feature-authentication", "requestGoogleLogin, googleSignInOption: ${googleSignInOption}")
     return GoogleSignIn.getClient(context.findActivity(), googleSignInOption)
 }
@@ -106,6 +102,7 @@ internal fun LoginRoute(
                 )
             }
         }
+
     fun handleGoogleLogin() {
         googleSignInClient.signOut()
         val signInIntent = googleSignInClient.signInIntent

--- a/feature-userInfo/src/main/java/com/hmoa/feature_userinfo/viewModel/MyPageViewModel.kt
+++ b/feature-userInfo/src/main/java/com/hmoa/feature_userinfo/viewModel/MyPageViewModel.kt
@@ -11,16 +11,7 @@ import com.hmoa.core_domain.repository.LoginRepository
 import com.hmoa.core_domain.repository.MemberRepository
 import com.hmoa.core_domain.usecase.GetMyUserInfoUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onEmpty
-import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -113,8 +104,8 @@ class MyPageViewModel @Inject constructor(
     //로그아웃
     fun logout() {
         viewModelScope.launch {
-            fcmRepository.deleteFcmToken()
-            loginRepository.deleteFcmToken()
+            fcmRepository.deleteRemoteFcmToken()
+            fcmRepository.deleteLocalFcmToken()
             loginRepository.deleteAuthToken()
             loginRepository.deleteRememberedToken()
         }
@@ -123,8 +114,8 @@ class MyPageViewModel @Inject constructor(
     //계정 삭제
     fun delAccount() {
         viewModelScope.launch {
-            fcmRepository.deleteFcmToken()
-            loginRepository.deleteFcmToken()
+            fcmRepository.deleteRemoteFcmToken()
+            fcmRepository.deleteLocalFcmToken()
             try {
                 memberRepository.deleteMember()
             } catch (e: Exception) {


### PR DESCRIPTION
## ApiResponse 추가
토큰 만료 상태로 시작할때의 앱이 튕기는 이슈에 대한 해결입니다
## LoginRepository -> FcmRepository로 이동
FcmToken을 로컬에 저장하는 경로 도메인을 Login에서 Fcm으로 수정했습니다.
FcmRepository에서 FcmRemoteDataStore(서버api), FcmLocalDataStore(TokenPreference)로 나뉘게 됩니다.