### PR TITLE
HMOA-38--signupflow 회원가입 플로우 수정

### DIFF
--- a/app/src/main/java/com/hmoa/app/MainActivity.kt
+++ b/app/src/main/java/com/hmoa/app/MainActivity.kt
@@ -90,7 +90,7 @@ class MainActivity : AppCompatActivity() {
         installSplashScreen()
         WindowCompat.setDecorFitsSystemWindows(window, false)
         requestNotificationPermission()
-        checkFcmToken()
+        //checkFcmToken()
 
         lifecycleScope.launch {
             val currentJob = coroutineContext.job

--- a/app/src/main/java/com/hmoa/app/navigation/NavHost.kt
+++ b/app/src/main/java/com/hmoa/app/navigation/NavHost.kt
@@ -40,16 +40,16 @@ fun SetUpNavGraph(
 
         /** authentication 모듈 */
         loginScreen(
-            onSignupClick = { navController.navigateToSignup() },
+            onSignupClick = { navController.navigateToSignup(it) },
             onHomeClick = { navController.navigateToHome() })
-        signupScreen(onPickNicknameClick = { navController.navigateToPickNickname() })
+        signupScreen(onPickNicknameClick = { navController.navigateToPickNickname(it) })
         pickNicknameScreen(
-            onPickPersonalInfoClick = { navController.navigateToPickPersonalInfo() },
-            onSignupClick = { navController.navigateToSignup() }
+            onPickPersonalInfoClick = { navController.navigateToPickPersonalInfo(it) },
+            onSignupClick = { navController.navigateToSignup(it) }
         )
         pickPersonalInfoScreen(
             onHomeClick = navController::navigateToHome,
-            onPickNicknameClick = { navController.navigateToPickNickname() }
+            onPickNicknameClick = { navController.navigateToPickNickname(it) }
         )
 
         /** like 모듈 */

--- a/core-database/src/main/java/com/hmoa/core_database/TokenManagerImpl.kt
+++ b/core-database/src/main/java/com/hmoa/core_database/TokenManagerImpl.kt
@@ -1,7 +1,6 @@
 package com.hmoa.core_database
 
 import android.content.Context
-import android.util.Log
 import androidx.datastore.core.DataStore
 import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.core.Preferences
@@ -15,7 +14,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 val Context.datastore: DataStore<Preferences> by preferencesDataStore(
@@ -40,14 +38,12 @@ class TokenManagerImpl @Inject constructor(@ApplicationContext context: Context)
 
     override suspend fun getAuthToken(): Flow<String?> {
         return dataStore.data.map { preferences ->
-            Log.d("TokenManagerImpl", "getAuthToken:${preferences[AUTH_TOKEN_KEY]}")
             preferences[AUTH_TOKEN_KEY]
         }
     }
 
     override suspend fun getRememberedToken(): Flow<String?> {
         return dataStore.data.map { preferences ->
-            Log.d("TokenManagerImpl", "getRememeberedToken:${preferences[REMEMBERED_TOKEN_KEY]}")
             preferences[REMEMBERED_TOKEN_KEY]
         }
     }
@@ -65,7 +61,7 @@ class TokenManagerImpl @Inject constructor(@ApplicationContext context: Context)
     }
 
     override suspend fun getFcmToken(): Flow<String?> {
-        return dataStore.data.map{ preferences ->
+        return dataStore.data.map { preferences ->
             preferences[FCM_TOKEN_KEY]
         }
     }
@@ -73,24 +69,18 @@ class TokenManagerImpl @Inject constructor(@ApplicationContext context: Context)
     override suspend fun saveAuthToken(token: String) {
         dataStore.edit { preferences ->
             preferences[AUTH_TOKEN_KEY] = token
-            Log.d("TokenManagerImpl", "let's save authToken:${token}")
-            Log.d("TokenManagerImpl", "it's saved authToken:${preferences[AUTH_TOKEN_KEY]}")
         }
     }
 
     override suspend fun saveRememberedToken(token: String) {
         dataStore.edit { preferences ->
             preferences[REMEMBERED_TOKEN_KEY] = token
-            Log.d("TokenManagerImpl", "let's save rememberedToken:${token}}")
-            Log.d("TokenManagerImpl", "it's saved rememberedToken:${preferences[REMEMBERED_TOKEN_KEY]}")
         }
     }
 
     override suspend fun saveKakaoAccessToken(token: String) {
-        CoroutineScope(Dispatchers.IO).launch {
-            dataStore.edit { preferences ->
-                preferences[KAKAO_ACCESS_TOKEN_KEY] = token
-            }
+        dataStore.edit { preferences ->
+            preferences[KAKAO_ACCESS_TOKEN_KEY] = token
         }
     }
 
@@ -101,7 +91,7 @@ class TokenManagerImpl @Inject constructor(@ApplicationContext context: Context)
     }
 
     override suspend fun saveFcmToken(token: String) {
-        dataStore.edit{ preferences ->
+        dataStore.edit { preferences ->
             preferences[FCM_TOKEN_KEY] = token
         }
     }
@@ -131,7 +121,7 @@ class TokenManagerImpl @Inject constructor(@ApplicationContext context: Context)
     }
 
     override suspend fun deleteFcmToken() {
-        dataStore.edit{ preferences ->
+        dataStore.edit { preferences ->
             preferences.remove(FCM_TOKEN_KEY)
         }
     }

--- a/core-datastore/src/main/java/com/hmoa/core_datastore/Login/LoginLocalDataStoreImpl.kt
+++ b/core-datastore/src/main/java/com/hmoa/core_datastore/Login/LoginLocalDataStoreImpl.kt
@@ -1,6 +1,5 @@
 package com.hmoa.core_datastore.Login
 
-import android.util.Log
 import com.hmoa.core_database.TokenManager
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
@@ -10,31 +9,29 @@ class LoginLocalDataStoreImpl @Inject constructor(
 ) : LoginLocalDataStore {
     override suspend fun getAuthToken(): Flow<String?> {
         val token = tokenManager.getAuthToken()
-        Log.d("LoginLocalDataStoreImpl", "getAuthToken:${token}")
         return token
     }
 
     override suspend fun getRememberedToken(): Flow<String?> {
         val token = tokenManager.getRememberedToken()
-        Log.d("LoginLocalDataStoreImpl", "getRememberedToken:${token}")
         return token
     }
 
     override suspend fun getKakaoAccessToken(): Flow<String?> {
-        return tokenManager.getKakaoAccessToken()
+        val token = tokenManager.getKakaoAccessToken()
+        return token
     }
 
     override suspend fun getGoogleAccessToken(): Flow<String?> {
-        return tokenManager.getGoogleAccessToken()
+        val token = tokenManager.getGoogleAccessToken()
+        return token
     }
 
     override suspend fun saveAuthToken(token: String) {
-        Log.d("LoginLocalDataStoreImpl", "saveAuthToken:${token}")
         tokenManager.saveAuthToken(token)
     }
 
     override suspend fun saveRememberedToken(token: String) {
-        Log.d("LoginLocalDataStoreImpl", "saveRememberedToken:${token}")
         tokenManager.saveRememberedToken(token)
     }
 

--- a/core-designsystem/src/main/java/com/hmoa/core_designsystem/component/ErrorUiSetView.kt
+++ b/core-designsystem/src/main/java/com/hmoa/core_designsystem/component/ErrorUiSetView.kt
@@ -17,7 +17,6 @@ fun ErrorUiSetView(onConfirmClick: () -> Unit, errorUiState: ErrorUiState, onClo
     when (errorUiState) {
         is ErrorUiState.ErrorData -> {
             if (errorUiState.expiredTokenError) {
-
                 AppDesignDialog(
                     isOpen = isOpen,
                     modifier = Modifier.wrapContentHeight()

--- a/core-repository/src/main/java/com/hmoa/core_repository/LoginRepositoryImpl.kt
+++ b/core-repository/src/main/java/com/hmoa/core_repository/LoginRepositoryImpl.kt
@@ -20,22 +20,22 @@ class LoginRepositoryImpl @Inject constructor(
 ) : com.hmoa.core_domain.repository.LoginRepository {
     override suspend fun getAuthToken(): Flow<String?> {
         val token = loginLocalDataStore.getAuthToken()
-        Log.d("LoginRepositoryImpl", "getAuthToken:${token}")
         return token
     }
 
     override suspend fun getRememberedToken(): Flow<String?> {
         val token = loginLocalDataStore.getRememberedToken()
-        Log.d("LoginRepositoryImpl", "getRememberedToken:${token}")
         return token
     }
 
     override suspend fun getKakaoAccessToken(): Flow<String?> {
-        return loginLocalDataStore.getKakaoAccessToken()
+        val token = loginLocalDataStore.getKakaoAccessToken()
+        return token
     }
 
     override suspend fun getGoogleAccessToken(): Flow<String?> {
-        return loginLocalDataStore.getGoogleAccessToken()
+        val token = loginLocalDataStore.getGoogleAccessToken()
+        return token
     }
 
     override suspend fun postOAuth(

--- a/feature-authentication/src/main/java/com/hmoa/feature_authentication/PickPersonalInfoScreen.kt
+++ b/feature-authentication/src/main/java/com/hmoa/feature_authentication/PickPersonalInfoScreen.kt
@@ -1,29 +1,16 @@
 package com.hmoa.feature_authentication
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
@@ -41,32 +28,32 @@ import com.hmoa.core_designsystem.component.Button
 import com.hmoa.core_designsystem.component.RadioButtonList
 import com.hmoa.core_designsystem.theme.CustomColor
 import com.hmoa.feature_authentication.viewmodel.PickPersonalInfoViewmodel
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 @Composable
 internal fun PickPersonalInfoRoute(
     onHomeClick: () -> Unit,
     onPickNicknameClick: () -> Unit,
+    loginProvider: String,
     viewModel: PickPersonalInfoViewmodel = hiltViewModel()
 ) {
-    val scope = CoroutineScope(Dispatchers.IO)
     val birthYearState by viewModel.birthYearState.collectAsStateWithLifecycle()
     val sexState by viewModel.sexState.collectAsStateWithLifecycle()
     val isPostComplete by viewModel.isPostComplete.collectAsStateWithLifecycle()
-    val context = LocalContext.current
+
     LaunchedEffect(isPostComplete) {
         if (isPostComplete) {
             onHomeClick()
         }
     }
 
+    LaunchedEffect(true) {
+        viewModel.getGoogleAccessToken()
+    }
+
     PickPersonalInfoScreen(
         onHomeClick = {
-            scope.launch {
-                viewModel.postSignup(birthYear = birthYearState, sex = sexState)
-            }
+            viewModel.signup(loginProvider = loginProvider, birthYear = birthYearState, sex = sexState)
         },
         onPickNicknameClick = { onPickNicknameClick() },
         onClickBirthYear = { viewModel.saveBirthYear(it) },
@@ -162,7 +149,8 @@ fun PickPersonalInfoScreen(
                     )
                 }
             }
-            Button(isAvailableButtonState, "시작하기", { onHomeClick() },
+            Button(
+                isAvailableButtonState, "시작하기", { onHomeClick() },
                 buttonModifier = Modifier.fillMaxWidth().height(80.dp)
             )
         }

--- a/feature-authentication/src/main/java/com/hmoa/feature_authentication/navigation/AuthenticationNavigation.kt
+++ b/feature-authentication/src/main/java/com/hmoa/feature_authentication/navigation/AuthenticationNavigation.kt
@@ -2,66 +2,78 @@ package com.hmoa.feature_authentication.navigation
 
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavType
 import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
 import com.hmoa.feature_authentication.LoginRoute
 import com.hmoa.feature_authentication.PickNicknameRoute
 import com.hmoa.feature_authentication.PickPersonalInfoRoute
 import com.hmoa.feature_authentication.SignupRoute
 
 fun NavController.navigateToLogin() = navigate("${AuthenticationRoute.Login}")
-fun NavController.navigateToSignup() =
-    navigate("${AuthenticationRoute.Signup}")
+fun NavController.navigateToSignup(loginProvider: String) =
+    navigate("${AuthenticationRoute.Signup}/${loginProvider}")
 
-fun NavController.navigateToPickNickname() =
-    navigate("${AuthenticationRoute.PickNickname}")
+fun NavController.navigateToPickNickname(loginProvider: String) =
+    navigate("${AuthenticationRoute.PickNickname}/${loginProvider}")
 
-fun NavController.navigateToPickPersonalInfo() =
-    navigate("${AuthenticationRoute.PickPersonalInfo}")
+fun NavController.navigateToPickPersonalInfo(loginProvider: String) =
+    navigate("${AuthenticationRoute.PickPersonalInfo}/${loginProvider}")
 
 fun NavGraphBuilder.loginScreen(
-    onSignupClick: () -> Unit,
-    onHomeClick: () -> Unit
+    onSignupClick: (loginProvider: String) -> Unit,
+    onHomeClick: () -> Unit,
 ) {
-    composable(route = "${AuthenticationRoute.Login}") {
+    composable(
+        route = "${AuthenticationRoute.Login}"
+    ) {
         LoginRoute(
-            onSignup = { onSignupClick() },
+            onSignup = { onSignupClick(it) },
             onHome = { onHomeClick() })
     }
 }
 
 fun NavGraphBuilder.signupScreen(
-    onPickNicknameClick: () -> Unit,
+    onPickNicknameClick: (loginProvider: String) -> Unit,
 ) {
     composable(
-        "${AuthenticationRoute.Signup}",
+        "${AuthenticationRoute.Signup}/{loginProvider}",
+        arguments = listOf(navArgument("loginProvider") { type = NavType.StringType })
     ) {
-        SignupRoute(onPickNicknameClick = { onPickNicknameClick() })
+        val loginProvider = it.arguments?.getString("loginProvider")
+        SignupRoute(onPickNicknameClick = { onPickNicknameClick(loginProvider!!) })
     }
 }
 
 fun NavGraphBuilder.pickNicknameScreen(
-    onPickPersonalInfoClick: () -> Unit,
-    onSignupClick: () -> Unit
+    onPickPersonalInfoClick: (loginProvider: String) -> Unit,
+    onSignupClick: (loginProvider: String) -> Unit
 ) {
     composable(
-        route = "${AuthenticationRoute.PickNickname}",
+        route = "${AuthenticationRoute.PickNickname}/{loginProvider}",
+        arguments = listOf(navArgument("loginProvider") { type = NavType.StringType })
     ) {
+        val loginProvider = it.arguments?.getString("loginProvider")
         PickNicknameRoute(
-            onPickPersonalInfoClick = { onPickPersonalInfoClick() },
-            onSignupClick = { onSignupClick() })
+            onPickPersonalInfoClick = { onPickPersonalInfoClick(loginProvider!!) },
+            onSignupClick = { onSignupClick(loginProvider!!) }
+        )
     }
 }
 
 
 fun NavGraphBuilder.pickPersonalInfoScreen(
     onHomeClick: () -> Unit,
-    onPickNicknameClick: () -> Unit,
+    onPickNicknameClick: (loginProvider: String) -> Unit,
 ) {
     composable(
-        route = "${AuthenticationRoute.PickPersonalInfo}",
+        route = "${AuthenticationRoute.PickPersonalInfo}/{loginProvider}",
+        arguments = listOf(navArgument("loginProvider") { type = NavType.StringType })
     ) {
+        val loginProvider = it.arguments?.getString("loginProvider")
         PickPersonalInfoRoute(
             onHomeClick = { onHomeClick() },
-            onPickNicknameClick = { onPickNicknameClick() })
+            onPickNicknameClick = { onPickNicknameClick(loginProvider!!) }, loginProvider = loginProvider!!
+        )
     }
 }

--- a/feature-authentication/src/main/java/com/hmoa/feature_authentication/viewmodel/PickPersonalInfoViewmodel.kt
+++ b/feature-authentication/src/main/java/com/hmoa/feature_authentication/viewmodel/PickPersonalInfoViewmodel.kt
@@ -1,22 +1,29 @@
 package com.hmoa.feature_authentication.viewmodel
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.hmoa.core_common.Result
 import com.hmoa.core_common.asResult
+import com.hmoa.core_domain.repository.LoginRepository
 import com.hmoa.core_domain.usecase.GetNicknameUseCase
 import com.hmoa.core_domain.usecase.PostSignupUseCase
+import com.hmoa.core_domain.usecase.SaveAuthAndRememberedTokenUseCase
+import com.hmoa.core_model.Provider
+import com.hmoa.core_model.request.OauthLoginRequestDto
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.update
-import java.util.Calendar
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
+import java.util.*
 import javax.inject.Inject
 
 @HiltViewModel
 class PickPersonalInfoViewmodel @Inject constructor(
     private val getNickname: GetNicknameUseCase,
-    private val postSignupInfo: PostSignupUseCase
+    private val postSignupInfo: PostSignupUseCase,
+    private val loginRepository: LoginRepository,
+    private val saveAuthAndRememberedToken: SaveAuthAndRememberedTokenUseCase
 ) : ViewModel() {
     private val _birthYearState = MutableStateFlow<Int?>(null)
     var birthYearState = _birthYearState.asStateFlow()
@@ -37,23 +44,93 @@ class PickPersonalInfoViewmodel @Inject constructor(
         _sexState.update { value }
     }
 
-    suspend fun postSignup(birthYear: Int?, sex: String) {
-        if (birthYear == null) return
-        val age = mapBirthYearToAge(birthYear)
-        val sex = mapSexToBoolean(sex)
-        val nickname = getSavedNickname()
-        if (!isAvailableToSignup(nickname, age)) return
-        postSignupInfo(age, sex, nickname = nickname!!).asResult()
-            .collectLatest { result ->
-                when (result) {
-                    is Result.Success -> {
-                        _isPostComplete.update { true }
+    fun signup(loginProvider: String, birthYear: Int?, sex: String) {
+        viewModelScope.launch(Dispatchers.IO) {
+            var token: String? = ""
+            when (loginProvider) {
+                Provider.GOOGLE.name -> {
+                    loginRepository.getGoogleAccessToken().collectLatest { token = it }
+                    if (token != null) {
+                        postAccessToken(token!!, Provider.GOOGLE, birthYear, sex)
                     }
+                }
 
-                    is Result.Loading -> {}//TODO("로딩화면")
-                    is Result.Error -> {}//TODO()
+                Provider.KAKAO.name -> {
+                    loginRepository.getKakaoAccessToken().collectLatest { token = it }
+                    Log.d("PickPersonalInfoViewmodel", "kakaoToken : ${token}")
+                    if (token != null) {
+                        postAccessToken(token!!, Provider.GOOGLE, birthYear, sex)
+                    }
                 }
             }
+        }
+    }
+
+    fun getGoogleAccessToken() {
+        viewModelScope.launch(Dispatchers.IO) {
+            loginRepository.getGoogleAccessToken().onEmpty { }
+                .collectLatest {
+                    Log.d("PickPersonalInfoViewmodel", "googleToken-in flow : ${it}")
+                }
+        }
+    }
+
+    suspend fun postAccessToken(token: String, loginProvider: Provider, birthYear: Int?, sex: String) {
+        viewModelScope.launch {
+            flow {
+                val result = loginRepository.postOAuth(OauthLoginRequestDto(token), provider = loginProvider)
+                if (result.errorMessage != null) {
+                    throw Exception(result.errorMessage!!.message)
+                } else {
+                    emit(result.data)
+                }
+            }.asResult()
+                .collectLatest {
+                    when (it) {
+                        is Result.Success -> {
+                            val authToken = it.data?.authToken
+                            val rememberedToken = it.data?.rememberedToken
+                            if (it.data != null && authToken != null && rememberedToken != null) {
+                                saveAuthAndRememberedToken(authToken, rememberedToken)
+                                postSignup(birthYear, sex)
+                            }
+
+                        }
+
+                        is Result.Loading -> {
+                            LoginUiState.Loading
+                        }
+
+                        is Result.Error -> {}
+                    }
+                }
+        }
+    }
+
+    fun postSignup(birthYear: Int?, sex: String) {
+        if (birthYear == null) return
+
+        val age = mapBirthYearToAge(birthYear)
+        val sex = mapSexToBoolean(sex)
+        var nickname: String? = ""
+
+        viewModelScope.launch { nickname = getSavedNickname() }
+
+        if (!isAvailableToSignup(nickname, age)) return
+
+        viewModelScope.launch {
+            postSignupInfo(age, sex, nickname = nickname!!).asResult()
+                .collectLatest { result ->
+                    when (result) {
+                        is Result.Success -> {
+                            _isPostComplete.update { true }
+                        }
+
+                        is Result.Loading -> {}
+                        is Result.Error -> {}
+                    }
+                }
+        }
     }
 
     fun isAvailableToSignup(nickname: String?, age: Int): Boolean {
@@ -82,3 +159,4 @@ class PickPersonalInfoViewmodel @Inject constructor(
         return true
     }
 }
+

--- a/feature-userInfo/src/main/java/com/hmoa/feature_userinfo/viewModel/MyPageViewModel.kt
+++ b/feature-userInfo/src/main/java/com/hmoa/feature_userinfo/viewModel/MyPageViewModel.kt
@@ -1,5 +1,6 @@
 package com.example.feature_userinfo.viewModel
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hmoa.core_common.ErrorMessageType
@@ -96,6 +97,7 @@ class MyPageViewModel @Inject constructor(
     private fun getAuthToken() {
         viewModelScope.launch {
             loginRepository.getAuthToken().onEmpty { }.collectLatest {
+                Log.d("MyPageViewmodel", "googleToken-in flow : ${it}")
                 authTokenState.value = it
             }
         }


### PR DESCRIPTION
@uselessnaming 
# 회원가입 플로우 수정
기존에는 소셜로그인으로 액세스 토큰을 받자마자 향모아 토큰 발급 후 저장을 하고, 회원가입 플로우를 시작했지만
회원가입 플로우 도중 이탈했다가 돌아올 경우 회원가입을 하지 않았는데 바로 MainActivity로 넘어가는 문제가 있었습니다!

그래서 기존 멤버인지 확인이 끝나면 향모아 토큰을 다시 지우고, 회원가입 플로우 마지막에 다시 향모아 토큰을 발급해서 저장하는 방식으로 변경했습니다!

# checkFcmToken 함수 내부 조건문 수정
토큰이 완전 없는 상태로 앱을 시작할 경우 앱이 튕기는 데 그 이유가
if 조건이 authToken, rememberToken이 모두 null인 경우 이고, 해당 조건의 else인 경우에 getFcmToken을 해서 인 것 같습니다.
authToken이 Null이어도 rememberToken이 먼저 null이 아니게 되면 else조건문이 작동해서 튕긴다고 생각했습니다..
그래서 아래와 같이 if authToken, rememberToken이 모두 null인 경우 getFcmToken구문이 있는 구조로 바꿨습니다.

```kotlin
if (authToken != null && rememberToken != null) {
    viewModel.postFcmToken(fcmToken.value!!)
    val fcmToken = viewModel.getFcmToken().stateIn(this)
    if (fcmToken.value == null) {
        FirebaseMessaging.getInstance().token.addOnSuccessListener {
            viewModel.saveFcmToken(it)
            viewModel.postFcmToken(it)
        }.addOnFailureListener {
            Log.e("Firebase Token", "Fail to save fcm token")
        }
    } else {
        viewModel.postFcmToken(fcmToken.value!!)
    }
} else {
    return@launch
}
```
