### PR TITLE
향수페이지 좋아요 상태관리/리프레시 불일치 수정

### DIFF
--- a/core-designsystem/src/main/java/com/hmoa/core_designsystem/component/CommentItem.kt
+++ b/core-designsystem/src/main/java/com/hmoa/core_designsystem/component/CommentItem.kt
@@ -8,8 +8,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -37,7 +35,7 @@ fun CommentItem(
     onCommentItemClick: () -> Unit,
     onCommentLikedClick: () -> Unit
 ) {
-    var isLiked = remember { mutableStateOf(isCommentLiked) }
+    //var isLiked = remember { mutableStateOf(isCommentLiked) }
     Column {
         Column(modifier = Modifier.fillMaxWidth().height(102.dp).padding(10.dp).clickable { onCommentItemClick() }) {
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
@@ -65,13 +63,12 @@ fun CommentItem(
                 Row {
                     LikeCountButton(
                         onClickItem = {
-                            isLiked.value = !isLiked.value
                             onCommentLikedClick()
                         },
                         count = count,
                         fontSize = TextUnit(value = 14f, type = TextUnitType.Sp),
                         fontColor = Color.Black,
-                        selected = isLiked.value,
+                        selected = isCommentLiked,
                         iconSize = 18
                     )
                     Icon(

--- a/core-model/src/main/java/com/hmoa/core_model/response/PerfumeCommentResponseDto.kt
+++ b/core-model/src/main/java/com/hmoa/core_model/response/PerfumeCommentResponseDto.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Serializable
 data class PerfumeCommentResponseDto(
     var content: String,
     val createdAt: String?,
-    val heartCount: Int,
+    var heartCount: Int,
     val id: Int,
     var liked: Boolean,
     val nickname: String,

--- a/feature-perfume/src/main/java/com/hmoa/feature_perfume/screen/PerfumeCommentScreen.kt
+++ b/feature-perfume/src/main/java/com/hmoa/feature_perfume/screen/PerfumeCommentScreen.kt
@@ -110,7 +110,7 @@ fun PerfumeCommentScreen(
                     onSpecificCommentClick = { commentId, isEditable -> onSpecificCommentClick(commentId, isEditable) },
                     onSpecificCommentLikeClick = { commentId, isLike, index ->
                         if (viewModel.getHasToken()) {
-                            viewModel.updatePerfumeCommentLike(commentId = commentId, like = isLike, index = index)
+                            viewModel.updatePerfumeCommentLike(commentId = commentId, like = isLike)
                             when ((uiState as PerfumeCommentViewmodel.PerfumeCommentUiState.CommentData).sortType) {
                                 SortType.LATEST -> latestPerfumeComments?.refresh()
                                 SortType.LIKE -> likePerfumeComments?.refresh()
@@ -196,17 +196,18 @@ fun PerfumeCommentContent(
                         onSortLatestClick = { onSortLatestClick() },
                         sortType = sortType
                     )
-                    when (sortType) {
-                        SortType.LATEST -> PerfumeCommentList(
+                    if (sortType == SortType.LIKE) {
+                        PerfumeCommentList(
                             likePerfumeComments,
                             {
                                 saveReportTargetId(it)
                                 scope.launch { modalSheetState.show() }
                             },
                             { id, isWrited -> onSpecificCommentClick(id, isWrited) },
-                            { commentId, isLike, index -> onSpecificCommentLikeClick(commentId, isLike, index) })
-
-                        SortType.LIKE -> PerfumeCommentList(
+                            { commentId, isLike, index -> onSpecificCommentLikeClick(commentId, isLike, index) }
+                        )
+                    } else {
+                        PerfumeCommentList(
                             latestPerfumeComments,
                             {
                                 saveReportTargetId(it)
@@ -216,7 +217,6 @@ fun PerfumeCommentContent(
                             { commentId, isLike, index -> onSpecificCommentLikeClick(commentId, isLike, index) }
                         )
                     }
-
                 }
             }
             BottomCommentAddBar(onAddCommentClick = { onAddCommentClick() })

--- a/feature-perfume/src/main/java/com/hmoa/feature_perfume/screen/PerfumeScreen.kt
+++ b/feature-perfume/src/main/java/com/hmoa/feature_perfume/screen/PerfumeScreen.kt
@@ -32,7 +32,10 @@ import com.hmoa.core_designsystem.theme.CustomColor
 import com.hmoa.core_model.PerfumeGender
 import com.hmoa.core_model.Weather
 import com.hmoa.core_model.data.Perfume
-import com.hmoa.core_model.response.*
+import com.hmoa.core_model.response.PerfumeAgeResponseDto
+import com.hmoa.core_model.response.PerfumeCommentResponseDto
+import com.hmoa.core_model.response.PerfumeGenderResponseDto
+import com.hmoa.core_model.response.PerfumeWeatherResponseDto
 import com.hmoa.feature_perfume.viewmodel.PerfumeViewmodel
 import kotlinx.coroutines.launch
 
@@ -80,10 +83,12 @@ fun PerfumeScreen(
     LaunchedEffect(true) {
         viewModel.initializePerfume(perfumeId)
     }
+
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val perfumeCommentIdToReport by viewModel.perfumeCommentIdStateToReport.collectAsStateWithLifecycle()
+    val perfumeComentCount by viewModel.perfumeCommentsCountState.collectAsStateWithLifecycle()
+    val isPerfumeCommentUpdated by viewModel.isPerfumeCommentUpdated.collectAsStateWithLifecycle()
     val errorUiState by viewModel.errorUiState.collectAsStateWithLifecycle()
-    val errorDialogAbleToPopUp = remember { mutableStateOf(true) }
 
     ErrorUiSetView(
         onConfirmClick = { onErrorHandleLoginAgain() },
@@ -115,6 +120,8 @@ fun PerfumeScreen(
                 gender = (uiState as PerfumeViewmodel.PerfumeUiState.PerfumeData).gender,
                 age = (uiState as PerfumeViewmodel.PerfumeUiState.PerfumeData).age,
                 perfumeComments = (uiState as PerfumeViewmodel.PerfumeUiState.PerfumeData).perfumeComments,
+                perfumeCommentsCount = perfumeComentCount,
+                isPerfumeCommentUpdated = isPerfumeCommentUpdated,
                 onSpecificCommentClick = { commentId, isEditable ->
                     onSpecificCommentClick(
                         commentId,
@@ -160,7 +167,9 @@ fun PerfumeContent(
     weather: PerfumeWeatherResponseDto?,
     gender: PerfumeGenderResponseDto?,
     age: PerfumeAgeResponseDto?,
-    perfumeComments: PerfumeCommentGetResponseDto?,
+    perfumeComments: List<PerfumeCommentResponseDto>?,
+    perfumeCommentsCount: Int,
+    isPerfumeCommentUpdated: Boolean,
     updatePerfumeCommentIdToReport: (commentId: Int) -> Unit
 ) {
     val verticalScrollState = rememberScrollState()
@@ -245,30 +254,28 @@ fun PerfumeContent(
                     onInitializeAgeClick = { onInitializeAgeClick() },
                     age
                 )
-                if (data.commentInfo != null) {
-                    CommentView(
-                        commentCount = perfumeComments?.commentCount ?: 0,
-                        perfumeComments = perfumeComments?.comments ?: emptyList(),
-                        onViewCommentAllClick = { onViewCommentAllClick(data.perfumeId.toInt()) },
-                        onSpecificCommentClick = { commentId, isEditable ->
-                            onSpecificCommentClick(
-                                commentId,
-                                isEditable
-                            )
-                        },
-                        onSpecificCommentLikeClick = { commentId, isLike, index ->
-                            onSpecificCommentLikeClick(
-                                commentId,
-                                isLike,
-                                index
-                            )
-                        },
-                        onPerfumeCommentReportClick = {
-                            updatePerfumeCommentIdToReport(it)
-                            scope.launch { modalSheetState.show() }
-                        },
-                    )
-                }
+                CommentView(
+                    commentCount = perfumeCommentsCount,
+                    perfumeComments = perfumeComments ?: emptyList(),
+                    onViewCommentAllClick = { onViewCommentAllClick(data.perfumeId.toInt()) },
+                    onSpecificCommentClick = { commentId, isEditable ->
+                        onSpecificCommentClick(
+                            commentId,
+                            isEditable
+                        )
+                    },
+                    onSpecificCommentLikeClick = { commentId, isLike, index ->
+                        onSpecificCommentLikeClick(
+                            commentId,
+                            isLike,
+                            index
+                        )
+                    },
+                    onPerfumeCommentReportClick = {
+                        updatePerfumeCommentIdToReport(it)
+                        scope.launch { modalSheetState.show() }
+                    },
+                )
                 Text(
                     "같은 브랜드의 제품",
                     style = TextStyle(fontSize = 20.sp, fontWeight = FontWeight.Medium),
@@ -591,16 +598,16 @@ fun CommentView(
             style = TextStyle(fontSize = 14.sp, fontWeight = FontWeight.Light)
         )
     }
-    when (commentCount) {
-        0 -> Text(
+    if (commentCount == 0) {
+        Text(
             "해당 제품에 대한 의견을 남겨주세요",
             style = TextStyle(fontSize = 14.sp, fontWeight = FontWeight.Medium, color = CustomColor.gray3),
             modifier = Modifier.fillMaxWidth().padding(vertical = 52.dp),
             textAlign = TextAlign.Center
         )
-
-        else -> {
-            perfumeComments.forEachIndexed { index, it ->
+    } else {
+        perfumeComments.forEachIndexed { index, it ->
+            key(it.id) {
                 CommentItem(
                     count = it.heartCount,
                     isCommentLiked = it.liked,
@@ -618,17 +625,17 @@ fun CommentView(
                     )
                 }
             }
-            Column(modifier = Modifier.padding(top = 8.dp)) {
-                Button(
-                    isEnabled = true,
-                    btnText = "모두 보기",
-                    onClick = { onViewCommentAllClick() },
-                    buttonModifier = Modifier.fillMaxWidth().height(32.dp).background(color = CustomColor.gray4),
-                    textColor = Color.White,
-                    textSize = 14
-                )
+        }
+        Column(modifier = Modifier.padding(top = 8.dp)) {
+            Button(
+                isEnabled = true,
+                btnText = "모두 보기",
+                onClick = { onViewCommentAllClick() },
+                buttonModifier = Modifier.fillMaxWidth().height(32.dp).background(color = CustomColor.gray4),
+                textColor = Color.White,
+                textSize = 14
+            )
 
-            }
         }
     }
 }

--- a/feature-perfume/src/main/java/com/hmoa/feature_perfume/screen/PerfumeScreen.kt
+++ b/feature-perfume/src/main/java/com/hmoa/feature_perfume/screen/PerfumeScreen.kt
@@ -87,7 +87,6 @@ fun PerfumeScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val perfumeCommentIdToReport by viewModel.perfumeCommentIdStateToReport.collectAsStateWithLifecycle()
     val perfumeComentCount by viewModel.perfumeCommentsCountState.collectAsStateWithLifecycle()
-    val isPerfumeCommentUpdated by viewModel.isPerfumeCommentUpdated.collectAsStateWithLifecycle()
     val errorUiState by viewModel.errorUiState.collectAsStateWithLifecycle()
 
     ErrorUiSetView(
@@ -121,7 +120,6 @@ fun PerfumeScreen(
                 age = (uiState as PerfumeViewmodel.PerfumeUiState.PerfumeData).age,
                 perfumeComments = (uiState as PerfumeViewmodel.PerfumeUiState.PerfumeData).perfumeComments,
                 perfumeCommentsCount = perfumeComentCount,
-                isPerfumeCommentUpdated = isPerfumeCommentUpdated,
                 onSpecificCommentClick = { commentId, isEditable ->
                     onSpecificCommentClick(
                         commentId,
@@ -169,7 +167,6 @@ fun PerfumeContent(
     age: PerfumeAgeResponseDto?,
     perfumeComments: List<PerfumeCommentResponseDto>?,
     perfumeCommentsCount: Int,
-    isPerfumeCommentUpdated: Boolean,
     updatePerfumeCommentIdToReport: (commentId: Int) -> Unit
 ) {
     val verticalScrollState = rememberScrollState()

--- a/feature-perfume/src/main/java/com/hmoa/feature_perfume/viewmodel/PerfumeViewmodel.kt
+++ b/feature-perfume/src/main/java/com/hmoa/feature_perfume/viewmodel/PerfumeViewmodel.kt
@@ -45,8 +45,6 @@ class PerfumeViewmodel @Inject constructor(
     private var perfumeCommentsState = MutableStateFlow<List<PerfumeCommentResponseDto>?>(null)
     private var _perfumeCommentsCountState = MutableStateFlow<Int>(0)
     val perfumeCommentsCountState: StateFlow<Int> = _perfumeCommentsCountState
-    private var _isPerfumeCommentUpdated = MutableStateFlow<Boolean>(false)
-    val isPerfumeCommentUpdated: StateFlow<Boolean> = _isPerfumeCommentUpdated
     private var _perfumeCommentIdStateToReport = MutableStateFlow<Int?>(null)
     val perfumeCommentIdStateToReport = _perfumeCommentIdStateToReport
 
@@ -301,7 +299,6 @@ class PerfumeViewmodel @Inject constructor(
             perfumeCommentsState.value = perfumeCommentsState.value?.map { comment ->
                 if (comment.id == newPerfumeComment.id) newPerfumeComment else comment
             }
-            _isPerfumeCommentUpdated.update { !_isPerfumeCommentUpdated.value }
             viewModelScope.launch(Dispatchers.IO) {
                 updateLikePerfumeComment(like, commentId)
             }


### PR DESCRIPTION
@uselessnaming 

상태관리 변수값이 변경되면 리컴포지션이 되어야 하는데, 
데이터 클래스 객체를 MutableStateFlow로 두고 그 내부 리스트를 바꾸는 방식에서
아예 내부 리스트를 MutableStateFlow로 했더니 됩니다 ㅠㅠ

```kotlin
sealed interface PerfumeUiState {
        data object Loading : PerfumeUiState
        data class PerfumeData(
            val data: Perfume?,
            val weather: PerfumeWeatherResponseDto?,
            val gender: PerfumeGenderResponseDto?,
            val age: PerfumeAgeResponseDto?,
            val perfumeComments: List<PerfumeCommentResponseDto>?,
        ) : PerfumeUiState

        data object Empty : PerfumeUiState
    }
```
향수댓글 페이지는 특이한 점이
리컴포지션 되어야 하는 컴포넌트가 when문 안에 있었는데, when문에 인자로 들어간 값이 변하지 않아서 리컴포지션이 안되었던 거였습니다