### PR TITLE
Feature/after anr solve 1.0.0 버전코드8 사전 출시 보고서 오류 수정

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
         applicationId = "com.hmoa.app"
         minSdk = 26
         targetSdk = 33
-        versionCode = 7
+        versionCode = 8
         versionName = "1.0.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
         applicationId = "com.hmoa.app"
         minSdk = 26
         targetSdk = 33
-        versionCode = 8
+        versionCode = 9
         versionName = "1.0.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/core-domain/src/main/java/com/hmoa/core_domain/usecase/GetNoteUseCase.kt
+++ b/core-domain/src/main/java/com/hmoa/core_domain/usecase/GetNoteUseCase.kt
@@ -1,0 +1,19 @@
+package com.hmoa.core_domain.usecase
+
+import com.hmoa.core_domain.repository.NoteRepository
+import com.hmoa.core_model.response.NoteDescResponseDto
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+class GetNoteUseCase @Inject constructor(private val noteRepository: NoteRepository) {
+    suspend operator fun invoke(id: Int): Flow<NoteDescResponseDto?> {
+        val result = noteRepository.getNote(id)
+        return flow {
+            if (result.errorMessage != null) {
+                throw Exception(result.errorMessage!!.message)
+            }
+            emit(result.data?.data)
+        }
+    }
+}

--- a/core-domain/src/main/java/com/hmoa/core_domain/usecase/GetPerfumerUseCase.kt
+++ b/core-domain/src/main/java/com/hmoa/core_domain/usecase/GetPerfumerUseCase.kt
@@ -1,0 +1,19 @@
+package com.hmoa.core_domain.usecase
+
+import com.hmoa.core_domain.repository.PerfumerRepository
+import com.hmoa.core_model.response.PerfumerDescResponseDto
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+class GetPerfumerUseCase @Inject constructor(private val perfumerRepository: PerfumerRepository) {
+    suspend operator fun invoke(id: Int): Flow<PerfumerDescResponseDto?> {
+        val result = perfumerRepository.getPerfumer(id)
+        return flow {
+            if (result.errorMessage != null) {
+                throw Exception(result.errorMessage!!.message)
+            }
+            emit(result.data?.data)
+        }
+    }
+}

--- a/core-domain/src/main/java/com/hmoa/core_domain/usecase/GetTermUseCase.kt
+++ b/core-domain/src/main/java/com/hmoa/core_domain/usecase/GetTermUseCase.kt
@@ -1,0 +1,19 @@
+package com.hmoa.core_domain.usecase
+
+import com.hmoa.core_domain.repository.TermRepository
+import com.hmoa.core_model.response.TermDescResponseDto
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+class GetTermUseCase @Inject constructor(private val termRepository: TermRepository) {
+    suspend operator fun invoke(id: Int): Flow<TermDescResponseDto?> {
+        val result = termRepository.getTerm(id)
+        return flow {
+            if (result.errorMessage != null) {
+                throw Exception(result.errorMessage!!.message)
+            }
+            emit(result.data?.data)
+        }
+    }
+}

--- a/core-model/src/main/java/com/hmoa/core_model/data/HpediaType.kt
+++ b/core-model/src/main/java/com/hmoa/core_model/data/HpediaType.kt
@@ -1,0 +1,5 @@
+package com.hmoa.core_model.data
+
+enum class HpediaType(val title:String) {
+    TERM("용어"),NOTE("노트"),PERFUMER("조향사")
+}

--- a/core-network/src/main/java/com/hmoa/core_network/di/ServiceModule.kt
+++ b/core-network/src/main/java/com/hmoa/core_network/di/ServiceModule.kt
@@ -52,7 +52,7 @@ object ServiceModule {
     @Provides
     fun provideHeaderInterceptor(tokenManager: TokenManager): Interceptor {
         val token = tokenManager.getAuthTokenForHeader()
-        
+
         return Interceptor { chain ->
             with(chain) {
                 val newRequest = request().newBuilder()

--- a/core-network/src/main/java/com/hmoa/core_network/di/ServiceModule.kt
+++ b/core-network/src/main/java/com/hmoa/core_network/di/ServiceModule.kt
@@ -12,7 +12,6 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
-import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import java.util.concurrent.TimeUnit
@@ -36,15 +35,12 @@ object ServiceModule {
     @Singleton
     @Provides
     fun provideOkHttpClient(headerInterceptor: Interceptor, authenticator: AuthAuthenticator): OkHttpClient {
-        val httpLoggingInterceptor = HttpLoggingInterceptor()
-        httpLoggingInterceptor.level = HttpLoggingInterceptor.Level.BODY
 
         val okHttpClientBuilder = OkHttpClient().newBuilder()
         okHttpClientBuilder.connectTimeout(60, TimeUnit.SECONDS)
         okHttpClientBuilder.readTimeout(60, TimeUnit.SECONDS)
         okHttpClientBuilder.authenticator(authenticator)
         okHttpClientBuilder.addInterceptor(headerInterceptor)
-        okHttpClientBuilder.addInterceptor(httpLoggingInterceptor)
         return okHttpClientBuilder.build()
     }
 

--- a/feature-hpedia/src/main/java/com/hmoa/feature_hpedia/Screen/HPediaDescScreen.kt
+++ b/feature-hpedia/src/main/java/com/hmoa/feature_hpedia/Screen/HPediaDescScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
@@ -17,6 +18,7 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hmoa.component.TopBar
+import com.hmoa.core_model.data.HpediaType
 import com.hmoa.feature_hpedia.ViewModel.HPediaDescUiState
 import com.hmoa.feature_hpedia.ViewModel.HPediaDescViewModel
 
@@ -27,16 +29,18 @@ fun HPediaDescRoute(
     onNavBack : () -> Unit,
     viewModel : HPediaDescViewModel = hiltViewModel()
 ){
-    viewModel.setInfo(
-        type = type,
-        id = id
-    )
+    LaunchedEffect(true){
+        viewModel.setInfo(
+            type = type,
+            id = id
+        )
+    }
 
     val uiState = viewModel.uiState.collectAsStateWithLifecycle()
     val type = viewModel.type.collectAsStateWithLifecycle()
 
     HPediaDescScreen(
-        type = type.value!!,
+        type = type.value,
         uiState = uiState.value,
         onNavBack = onNavBack,
     )
@@ -44,7 +48,7 @@ fun HPediaDescRoute(
 
 @Composable
 fun HPediaDescScreen(
-    type : String,
+    type : HpediaType,
     uiState : HPediaDescUiState,
     onNavBack : () -> Unit,
 ){
@@ -63,7 +67,7 @@ fun HPediaDescScreen(
                     .background(color = Color.White)
             ){
                 TopBar(
-                    title = type,
+                    title = type.title,
                     navIcon = painterResource(com.hmoa.core_designsystem.R.drawable.ic_back),
                     onNavClick = onNavBack
                 )

--- a/feature-hpedia/src/main/java/com/hmoa/feature_hpedia/ViewModel/HPediaDescViewModel.kt
+++ b/feature-hpedia/src/main/java/com/hmoa/feature_hpedia/ViewModel/HPediaDescViewModel.kt
@@ -4,110 +4,61 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hmoa.core_common.Result
 import com.hmoa.core_common.asResult
-import com.hmoa.core_domain.repository.NoteRepository
-import com.hmoa.core_domain.repository.PerfumerRepository
-import com.hmoa.core_domain.repository.TermRepository
+import com.hmoa.core_domain.usecase.GetNoteUseCase
+import com.hmoa.core_domain.usecase.GetPerfumerUseCase
+import com.hmoa.core_domain.usecase.GetTermUseCase
+import com.hmoa.core_model.data.HpediaType
 import com.hmoa.core_model.response.NoteDescResponseDto
 import com.hmoa.core_model.response.PerfumerDescResponseDto
 import com.hmoa.core_model.response.TermDescResponseDto
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class HPediaDescViewModel @Inject constructor(
-    private val termRepository: TermRepository,
-    private val noteRepository: NoteRepository,
-    private val perfumerRepository: PerfumerRepository
+    private val getTermUseCase: GetTermUseCase,
+    private val getNoteUseCase: GetNoteUseCase,
+    private val perfumerUseCase: GetPerfumerUseCase
 ) : ViewModel() {
 
-    private val id = MutableStateFlow<Int?>(null)
-
-    private val _type = MutableStateFlow<String?>(null)
+    private var _id = MutableStateFlow<Int?>(null)
+    private var _type = MutableStateFlow<HpediaType>(HpediaType.TERM)
     val type get() = _type.asStateFlow()
-
-    private val _errState = MutableStateFlow<String?>(null)
-    val errState get() = _errState.asStateFlow()
-
-    val uiState: StateFlow<HPediaDescUiState> = id.combine(
-        _type
-    ) { id, type ->
-        if (id == null || type == null) {
-            throw NullPointerException("Id or Type is NULL")
+    private var termDesc = MutableStateFlow<TermDescResponseDto?>(null)
+    private var noteDesc = MutableStateFlow<NoteDescResponseDto?>(null)
+    private var perfumerDesc = MutableStateFlow<PerfumerDescResponseDto?>(null)
+    val uiState: StateFlow<HPediaDescUiState> = combine(
+        _id, _type, termDesc, noteDesc, perfumerDesc
+    ) { id, type, term, note, perfumer ->
+        if (id == null) {
+            throw NullPointerException("Id is NULL")
         }
         when (type) {
-            "용어" -> {
-                val result = termRepository.getTerm(id)
-                if (result.errorMessage != null) {
-                    throw Exception(result.errorMessage!!.message)
-                }
-                result.data!!
+            HpediaType.TERM -> {
+                HPediaDescUiState.HPediaDesc(
+                    title = term?.termTitle ?: "",
+                    subTitle = term?.termEnglishTitle ?: "",
+                    content = term?.content ?: ""
+                )
             }
 
-            "노트" -> {
-                val result = noteRepository.getNote(id)
-                if (result.errorMessage != null) {
-                    throw Exception(result.errorMessage!!.message)
-                }
-                result.data!!
+            HpediaType.NOTE -> {
+                HPediaDescUiState.HPediaDesc(
+                    title = note?.noteTitle ?: "",
+                    subTitle = note?.noteSubtitle ?: "",
+                    content = note?.content ?: ""
+                )
             }
 
-            "조향사" -> {
-                val result = perfumerRepository.getPerfumer(id)
-                if (result.errorMessage != null) {
-                    throw Exception(result.errorMessage!!.message)
-                }
-                result.data!!
-            }
-
-            else -> {
-                throw IllegalArgumentException("Not Exist Type")
-            }
-        }
-    }.asResult().map { result ->
-        when (result) {
-            is Result.Error -> {
-                HPediaDescUiState.Error
-            }
-
-            is Result.Success -> {
-                val data = result.data
-                when (type.value) {
-                    "용어" -> {
-                        val term = data.data as TermDescResponseDto
-                        HPediaDescUiState.HPediaDesc(
-                            title = term.termTitle,
-                            subTitle = term.termEnglishTitle,
-                            content = term.content
-                        )
-                    }
-
-                    "노트" -> {
-                        val note = result.data as NoteDescResponseDto
-                        HPediaDescUiState.HPediaDesc(
-                            title = note.noteTitle,
-                            subTitle = note.noteSubtitle,
-                            content = note.content
-                        )
-                    }
-
-                    "조향사" -> {
-                        val perfumer = result.data as PerfumerDescResponseDto
-                        HPediaDescUiState.HPediaDesc(
-                            title = perfumer.perfumerTitle,
-                            subTitle = perfumer.perfumerSubTitle,
-                            content = perfumer.content
-                        )
-                    }
-
-                    else -> {
-                        HPediaDescUiState.Error
-                    }
-                }
-            }
-
-            is Result.Loading -> {
-                HPediaDescUiState.Loading
+            HpediaType.PERFUMER -> {
+                HPediaDescUiState.HPediaDesc(
+                    title = perfumer?.perfumerTitle ?: "",
+                    subTitle = perfumer?.perfumerSubTitle ?: "",
+                    content = perfumer?.content ?: ""
+                )
             }
         }
     }.stateIn(
@@ -117,10 +68,65 @@ class HPediaDescViewModel @Inject constructor(
     )
 
     fun setInfo(type: String?, id: Int?) {
-        this._type.update { type }
-        this.id.update { id }
+        viewModelScope.launch(Dispatchers.IO) {
+            _id.update { id }
+
+            if (id != null) {
+                when (type) {
+                    HpediaType.TERM.title -> {
+                        _type.update { HpediaType.TERM }
+                        getTermDesc(id)
+                    }
+
+                    HpediaType.NOTE.title -> {
+                        _type.update { HpediaType.NOTE }
+                        getNote(id)
+                    }
+
+                    HpediaType.PERFUMER.title -> {
+                        _type.update { HpediaType.PERFUMER }
+                        getPerfumer(id)
+                    }
+                }
+            }
+        }
     }
 
+    suspend fun getTermDesc(id: Int) {
+        getTermUseCase(id).asResult().collectLatest { result ->
+            when (result) {
+                is Result.Error -> HPediaDescUiState.Error
+                Result.Loading -> HPediaDescUiState.Loading
+                is Result.Success -> {
+                    termDesc.update { result.data }
+                }
+            }
+        }
+    }
+
+    suspend fun getNote(id: Int) {
+        getNoteUseCase(id).asResult().collectLatest { result ->
+            when (result) {
+                is Result.Error -> HPediaDescUiState.Error
+                Result.Loading -> HPediaDescUiState.Loading
+                is Result.Success -> {
+                    noteDesc.update { result.data }
+                }
+            }
+        }
+    }
+
+    suspend fun getPerfumer(id: Int) {
+        perfumerUseCase(id).asResult().collectLatest { result ->
+            when (result) {
+                is Result.Error -> HPediaDescUiState.Error
+                Result.Loading -> HPediaDescUiState.Loading
+                is Result.Success -> {
+                    perfumerDesc.update { result.data }
+                }
+            }
+        }
+    }
 }
 
 sealed interface HPediaDescUiState {


### PR DESCRIPTION
@uselessnaming 
## IllegalStateException:closed 오류
버전코드 7까지 인터셉터, 어센티케이터에 비동기부분을 모두 runBlocking처리를 했는데도 
대체 어떤 부분에서 응답스트림을 2번 읽은 건지 모르겠어서... HttpLogginInterceptor를 지워버렸습니다. 이제 디버깅할 때 로그에 무슨 요청과 응답을 했는지 볼 수는 없지만 일단 이렇게 해보았습니다!
```kotlin
 @Singleton
    @Provides
    fun provideOkHttpClient(headerInterceptor: Interceptor, authenticator: AuthAuthenticator): OkHttpClient {

        val okHttpClientBuilder = OkHttpClient().newBuilder()
        okHttpClientBuilder.connectTimeout(60, TimeUnit.SECONDS)
        okHttpClientBuilder.readTimeout(60, TimeUnit.SECONDS)
        okHttpClientBuilder.authenticator(authenticator)
        okHttpClientBuilder.addInterceptor(headerInterceptor) //headerInterceptor만 남았습니다
        return okHttpClientBuilder.build()
    }
```
## HPediaDescViewmodel 오류 수정 및 리팩토링
`java.lang.ClassCastException: com.hmoa.core_model.response.DataResponseDto cannot be cast to com.hmoa.core_model.response.NoteDescResponseDto`
용어, 노트,조향사 용어정의 화면에서 분기해서 받아오는 부분을 UseCase로 나눠버렸습니다..! 지금까지는 일단 놔두고 있었는데 에러처리 구문이 확정된 이후로 viewmodel 코드가 늘어난 것 같아서 UseCase로 나눠보았는데 어떤가요??🤔🤔🤔🤔

