### PR TITLE
Fix: 카카오 로그인 오류 해결 및 앱 키 참조 방식 변경

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
         applicationId = "com.hmoa.app"
         minSdk = 26
         targetSdk = 33
-        versionCode = 11
+        versionCode = 12
         versionName = "1.0.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,8 +26,8 @@ android {
         versionName = "1.0.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        manifestPlaceholders["NATIVE_APP_KEY"] = localProperties.getProperty("NATIVE_APP_KEY")
-        buildConfigField("String", "NATIVE_APP_KEY", localProperties.getProperty("NATIVE_APP_KEY"))
+        manifestPlaceholders["REDIRECTION_PATH"] = localProperties["REDIRECTION_PATH"] as String
+        buildConfigField("String", "NATIVE_APP_KEY", localProperties["NATIVE_APP_KEY"] as String)
     }
 
     signingConfigs {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -51,7 +51,7 @@
                 <!-- Redirect URI: "kakao${NATIVE_APP_KEY}://oauth" -->
                 <data
                         android:host="oauth"
-                        android:scheme="@string/native_app_key"/>
+                        android:scheme="${REDIRECTION_PATH}"/>
             </intent-filter>
         </activity> <!-- 서비스를 추가하고 인텐트 필터를 설정한다. -->
         <service

--- a/app/src/main/java/com/hmoa/app/App.kt
+++ b/app/src/main/java/com/hmoa/app/App.kt
@@ -1,7 +1,6 @@
 package com.hmoa.app
 
 import android.app.Application
-import android.util.Log
 import androidx.appcompat.app.AppCompatDelegate
 import com.kakao.sdk.common.KakaoSdk
 import dagger.hilt.android.HiltAndroidApp
@@ -12,5 +11,6 @@ class App : Application() {
         AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
         super.onCreate()
         KakaoSdk.init(this, BuildConfig.NATIVE_APP_KEY)
+
     }
 }


### PR DESCRIPTION
@uselessnaming 
## 카카오 로그인 오류 해결(구글 플레이 재제출 예정)
역시 제가 앱 키를 잘못 넣고있었습니다😬😬
redirection은 "kakao앱키"이고, App.kt의 "앱키" 초기화에는 앱키를 넣어야하는데 둘다 "kakao앱키"이렇게 넣고 있었네요..! gitignore된 파일이라 호준님과 저의 테스트 결과가 달랐던 거 같습니다.
그리고 진행될 CI환경개발을 고려해서 CI는 app/main/res/values/secret_information.xml을 참조할 수 없어서 local.properties의 값을 참조하도록 build.gradle.kts파일을 변경했습니다.
바뀐 app모듈의 local.properties [내용은]( https://github.com/HMOAA/HMOA_ANDROID_SECRET/blob/master/app/local.properties) 비공개 저장소에 있습니다. 일단은 해당 변경을 복붙해서 빌드하시면 됩니다!
CI환경 만들면서 빌드 전에 자동으로 비공개 저장소에서 파일내용들을 읽어올 수 있도록 수정해보겠습니다.
