### PR TITLE
Hotfix/kakaologin 오류 수정 후 구글 플레이 재제출

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,6 +2,5 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/HMOA_ANDROID_SECRET" vcs="Git" />
   </component>
 </project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
         applicationId = "com.hmoa.app"
         minSdk = 26
         targetSdk = 33
-        versionCode = 12
+        versionCode = 13
         versionName = "1.0.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/core-common/src/main/java/com/hmoa/core_common/ErrorMessageType.kt
+++ b/core-common/src/main/java/com/hmoa/core_common/ErrorMessageType.kt
@@ -3,5 +3,6 @@ package com.hmoa.core_common
 enum class ErrorMessageType(val code: Int, val message: String) {
     EXPIRED_TOKEN(401, "ACCESS Token이 만료되었습니다."),
     WRONG_TYPE_TOKEN(401, "변조된 토큰입니다."),
-    UNKNOWN_ERROR(404, "jwt가 존재하지 않습니다.")
+    UNKNOWN_ERROR(404, "jwt가 존재하지 않습니다."),
+    MEMBER_NOT_FOUND(404, "등록된 멤버가 없습니다.")
 }

--- a/core-common/src/main/java/com/hmoa/core_common/ErrorUiState.kt
+++ b/core-common/src/main/java/com/hmoa/core_common/ErrorUiState.kt
@@ -5,6 +5,7 @@ sealed interface ErrorUiState {
         val expiredTokenError: Boolean,
         val wrongTypeTokenError: Boolean,
         val unknownError: Boolean,
+        val memberNotFoundError: Boolean? = null,
         val generalError: Pair<Boolean, String?>
     ) : ErrorUiState
 

--- a/core-database/src/main/java/com/hmoa/core_database/TokenManager.kt
+++ b/core-database/src/main/java/com/hmoa/core_database/TokenManager.kt
@@ -3,7 +3,7 @@ package com.hmoa.core_database
 import kotlinx.coroutines.flow.Flow
 
 interface TokenManager {
-    fun getAuthTokenForHeader(): String
+    fun getAuthTokenForHeader(): String?
     suspend fun getAuthToken(): Flow<String?>
     suspend fun getRememberedToken(): Flow<String?>
     suspend fun getKakaoAccessToken(): Flow<String?>

--- a/core-database/src/main/java/com/hmoa/core_database/TokenManagerImpl.kt
+++ b/core-database/src/main/java/com/hmoa/core_database/TokenManagerImpl.kt
@@ -1,6 +1,7 @@
 package com.hmoa.core_database
 
 import android.content.Context
+import android.util.Log
 import androidx.datastore.core.DataStore
 import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.core.Preferences
@@ -13,8 +14,9 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 
@@ -38,15 +40,19 @@ class TokenManagerImpl @Inject constructor(@ApplicationContext context: Context)
         private val FCM_TOKEN_KEY = stringPreferencesKey("FCM_TOKEN")
     }
 
-    override fun getAuthTokenForHeader(): String {
-        val token = runBlocking {
-            getAuthToken().firstOrNull()
+    override fun getAuthTokenForHeader(): String? {
+        var token = runBlocking {
+            getAuthToken().first()
         }
-        return token ?: ""
+        //한 번 더 하는 이유는 첫 값이 null일 때가 있기 때문, 아직 원인은 모르는 문제이지만 임시방편으로 해결은 하는 것 뿐
+        token = runBlocking {
+            getAuthToken().first()
+        }
+        return token
     }
 
     override suspend fun getAuthToken(): Flow<String?> {
-        return dataStore.data.map { preferences ->
+        return dataStore.data.mapLatest { preferences ->
             preferences[AUTH_TOKEN_KEY]
         }
     }
@@ -65,6 +71,8 @@ class TokenManagerImpl @Inject constructor(@ApplicationContext context: Context)
 
     override suspend fun getGoogleAccessToken(): Flow<String?> {
         return dataStore.data.map { preferences ->
+            val p = preferences[GOOGLE_ACCESS_TOKEN_KEY]
+            Log.d("TokenManagerImpl", "${p}")
             preferences[GOOGLE_ACCESS_TOKEN_KEY]
         }
     }

--- a/core-network/src/main/java/com/hmoa/core_network/di/ServiceModule.kt
+++ b/core-network/src/main/java/com/hmoa/core_network/di/ServiceModule.kt
@@ -47,8 +47,7 @@ object ServiceModule {
     @Singleton
     @Provides
     fun provideHeaderInterceptor(tokenManager: TokenManager): Interceptor {
-        val token = tokenManager.getAuthTokenForHeader()
-
+        var token = tokenManager.getAuthTokenForHeader()
         return Interceptor { chain ->
             with(chain) {
                 val newRequest = request().newBuilder()

--- a/feature-userInfo/src/main/java/com/hmoa/feature_userinfo/viewModel/MyPageViewModel.kt
+++ b/feature-userInfo/src/main/java/com/hmoa/feature_userinfo/viewModel/MyPageViewModel.kt
@@ -29,17 +29,20 @@ class MyPageViewModel @Inject constructor(
     private var expiredTokenErrorState = MutableStateFlow<Boolean>(false)
     private var wrongTypeTokenErrorState = MutableStateFlow<Boolean>(false)
     private var unLoginedErrorState = MutableStateFlow<Boolean>(false)
+    private var memberNotFoundErrorState = MutableStateFlow<Boolean>(false)
     private var generalErrorState = MutableStateFlow<Pair<Boolean, String?>>(Pair(false, null))
     val errorUiState: StateFlow<ErrorUiState> = combine(
         expiredTokenErrorState,
         wrongTypeTokenErrorState,
         unLoginedErrorState,
+        memberNotFoundErrorState,
         generalErrorState
-    ) { expiredTokenError, wrongTypeTokenError, unknownError, generalError ->
+    ) { expiredTokenError, wrongTypeTokenError, unknownError, memberNotFoundError, generalError ->
         ErrorUiState.ErrorData(
             expiredTokenError = expiredTokenError,
             wrongTypeTokenError = wrongTypeTokenError,
             unknownError = unknownError,
+            memberNotFoundError = memberNotFoundError,
             generalError = generalError
         )
     }.stateIn(
@@ -74,6 +77,7 @@ class MyPageViewModel @Inject constructor(
                     ErrorMessageType.EXPIRED_TOKEN.message -> expiredTokenErrorState.update { true }
                     ErrorMessageType.WRONG_TYPE_TOKEN.message -> wrongTypeTokenErrorState.update { true }
                     ErrorMessageType.UNKNOWN_ERROR.message -> unLoginedErrorState.update { true }
+                    ErrorMessageType.MEMBER_NOT_FOUND.message -> memberNotFoundErrorState.update { true }
                     else -> generalErrorState.update { Pair(true, result.exception.message) }
                 }
                 UserInfoUiState.Error


### PR DESCRIPTION
@uselessnaming 
해당 PR 내용을 빌드해서 7/29일에 구글플레이에 재제출했습니다.
# 릴리즈 버전 카카오 로그인 오류 수정
릴리즈 버전에서 카카오 로그인이 안되는 현상이 있었는데
 키가 카카오 해시 키로 등록이 안되어 있어서 발생한 문제였습니다. 
# 토큰 빈 값 나오는 현상 수정
가끔씩 토큰이 빈 값이 나와서 토큰이 필요한 api 오류 응답을 받는 일이 있었습니다. 정확한 원인은 모르지만..일단 임시방편으로 함수 내부적으로 한 번더 값을 요청하는 방식으로 수정했습니다. 