### PR TITLE
Hotfix/errormessage 에러메세지 수정 후 재제출

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,6 +2,5 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/HMOA_ANDROID_SECRET" vcs="Git" />
   </component>
 </project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
         applicationId = "com.hmoa.app"
         minSdk = 26
         targetSdk = 33
-        versionCode = 12
+        versionCode = 13
         versionName = "1.0.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
         applicationId = "com.hmoa.app"
         minSdk = 26
         targetSdk = 33
-        versionCode = 13
+        versionCode = 14
         versionName = "1.0.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
         applicationId = "com.hmoa.app"
         minSdk = 26
         targetSdk = 33
-        versionCode = 14
+        versionCode = 15
         versionName = "1.0.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/core-common/src/main/java/com/hmoa/core_common/ErrorMessageType.kt
+++ b/core-common/src/main/java/com/hmoa/core_common/ErrorMessageType.kt
@@ -3,5 +3,6 @@ package com.hmoa.core_common
 enum class ErrorMessageType(val code: Int, val message: String) {
     EXPIRED_TOKEN(401, "ACCESS Token이 만료되었습니다."),
     WRONG_TYPE_TOKEN(401, "변조된 토큰입니다."),
-    UNKNOWN_ERROR(404, "jwt가 존재하지 않습니다.")
+    UNKNOWN_ERROR(404, "jwt가 존재하지 않습니다."),
+    MEMBER_NOT_FOUND(404, "등록된 멤버가 없습니다.")
 }

--- a/core-common/src/main/java/com/hmoa/core_common/ErrorUiState.kt
+++ b/core-common/src/main/java/com/hmoa/core_common/ErrorUiState.kt
@@ -5,6 +5,7 @@ sealed interface ErrorUiState {
         val expiredTokenError: Boolean,
         val wrongTypeTokenError: Boolean,
         val unknownError: Boolean,
+        val memberNotFoundError: Boolean? = null,
         val generalError: Pair<Boolean, String?>
     ) : ErrorUiState
 

--- a/core-database/src/main/java/com/hmoa/core_database/TokenManager.kt
+++ b/core-database/src/main/java/com/hmoa/core_database/TokenManager.kt
@@ -3,7 +3,7 @@ package com.hmoa.core_database
 import kotlinx.coroutines.flow.Flow
 
 interface TokenManager {
-    fun getAuthTokenForHeader(): String
+    fun getAuthTokenForHeader(): String?
     suspend fun getAuthToken(): Flow<String?>
     suspend fun getRememberedToken(): Flow<String?>
     suspend fun getKakaoAccessToken(): Flow<String?>

--- a/core-database/src/main/java/com/hmoa/core_database/TokenManagerImpl.kt
+++ b/core-database/src/main/java/com/hmoa/core_database/TokenManagerImpl.kt
@@ -1,6 +1,7 @@
 package com.hmoa.core_database
 
 import android.content.Context
+import android.util.Log
 import androidx.datastore.core.DataStore
 import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.core.Preferences
@@ -13,8 +14,9 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 
@@ -38,15 +40,19 @@ class TokenManagerImpl @Inject constructor(@ApplicationContext context: Context)
         private val FCM_TOKEN_KEY = stringPreferencesKey("FCM_TOKEN")
     }
 
-    override fun getAuthTokenForHeader(): String {
-        val token = runBlocking {
-            getAuthToken().firstOrNull()
+    override fun getAuthTokenForHeader(): String? {
+        var token = runBlocking {
+            getAuthToken().first()
         }
-        return token ?: ""
+        //한 번 더 하는 이유는 첫 값이 null일 때가 있기 때문, 아직 원인은 모르는 문제이지만 임시방편으로 해결은 하는 것 뿐
+        token = runBlocking {
+            getAuthToken().first()
+        }
+        return token
     }
 
     override suspend fun getAuthToken(): Flow<String?> {
-        return dataStore.data.map { preferences ->
+        return dataStore.data.mapLatest { preferences ->
             preferences[AUTH_TOKEN_KEY]
         }
     }
@@ -65,6 +71,8 @@ class TokenManagerImpl @Inject constructor(@ApplicationContext context: Context)
 
     override suspend fun getGoogleAccessToken(): Flow<String?> {
         return dataStore.data.map { preferences ->
+            val p = preferences[GOOGLE_ACCESS_TOKEN_KEY]
+            Log.d("TokenManagerImpl", "${p}")
             preferences[GOOGLE_ACCESS_TOKEN_KEY]
         }
     }

--- a/core-database/src/main/java/com/hmoa/core_database/TokenManagerImpl.kt
+++ b/core-database/src/main/java/com/hmoa/core_database/TokenManagerImpl.kt
@@ -43,7 +43,6 @@ class TokenManagerImpl @Inject constructor(@ApplicationContext context: Context)
     override fun getAuthTokenForHeader(): String? {
         val token = runBlocking {
             getAuthToken().first()
-            getAuthToken().first()
         }
         return token
     }

--- a/core-database/src/main/java/com/hmoa/core_database/TokenManagerImpl.kt
+++ b/core-database/src/main/java/com/hmoa/core_database/TokenManagerImpl.kt
@@ -41,11 +41,8 @@ class TokenManagerImpl @Inject constructor(@ApplicationContext context: Context)
     }
 
     override fun getAuthTokenForHeader(): String? {
-        var token = runBlocking {
+        val token = runBlocking {
             getAuthToken().first()
-        }
-        //한 번 더 하는 이유는 첫 값이 null일 때가 있기 때문, 아직 원인은 모르는 문제이지만 임시방편으로 해결은 하는 것 뿐
-        token = runBlocking {
             getAuthToken().first()
         }
         return token

--- a/core-designsystem/src/main/java/com/hmoa/core_designsystem/component/ErrorUiSetView.kt
+++ b/core-designsystem/src/main/java/com/hmoa/core_designsystem/component/ErrorUiSetView.kt
@@ -1,5 +1,6 @@
 package com.hmoa.core_designsystem.component
 
+import android.util.Log
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.runtime.*
@@ -14,6 +15,12 @@ fun ErrorUiSetView(onLoginClick: () -> Unit, errorUiState: ErrorUiState, onClose
     var isOpen by remember { mutableStateOf(true) }
     val screenWidth = LocalConfiguration.current.screenWidthDp.dp
 
+    LaunchedEffect(errorUiState) {
+        Log.d(
+            "MyPageViewModel",
+            "errorUiState.memberNotFoundError:${(errorUiState as ErrorUiState.ErrorData).memberNotFoundError}"
+        )
+    }
     when (errorUiState) {
         is ErrorUiState.ErrorData -> {
             if (errorUiState.expiredTokenError) {
@@ -67,11 +74,29 @@ fun ErrorUiSetView(onLoginClick: () -> Unit, errorUiState: ErrorUiState, onClose
                         onCloseClick()
                     }
                 )
+            } else if (errorUiState.memberNotFoundError ?: false) {
+                AppDesignDialog(
+                    isOpen = isOpen,
+                    modifier = Modifier.wrapContentHeight()
+                        .width(screenWidth - 88.dp),
+                    title = "사용자를 찾을 수 없습니다",
+                    content = "다시 로그인해주세요",
+                    buttonTitle = "로그인 하러가기",
+                    onOkClick = {
+                        isOpen = false
+                        onLoginClick()
+                    },
+                    onCloseClick = {
+                        isOpen = false
+                        onCloseClick()
+                    }
+                )
             } else if (errorUiState.generalError.first) {
                 AppDefaultDialog(
                     isOpen = isOpen,
                     title = "오류가 발생했어요 :(",
-                    content = (errorUiState as ErrorUiState.ErrorData).generalError.second ?: "",
+                    content = (errorUiState as ErrorUiState.ErrorData).generalError.second
+                        ?: "서비스 정상화를 위해 노력하고 있습니다 :)",
                     onDismiss = {
                         isOpen = false
                     },

--- a/core-designsystem/src/main/java/com/hmoa/core_designsystem/component/ErrorUiSetView.kt
+++ b/core-designsystem/src/main/java/com/hmoa/core_designsystem/component/ErrorUiSetView.kt
@@ -70,7 +70,7 @@ fun ErrorUiSetView(onLoginClick: () -> Unit, errorUiState: ErrorUiState, onClose
             } else if (errorUiState.generalError.first) {
                 AppDefaultDialog(
                     isOpen = isOpen,
-                    title = "이런 오류가 발생했어요 :(",
+                    title = "오류가 발생했어요 :(",
                     content = (errorUiState as ErrorUiState.ErrorData).generalError.second ?: "",
                     onDismiss = {
                         isOpen = false

--- a/core-designsystem/src/main/java/com/hmoa/core_designsystem/component/ErrorUiSetView.kt
+++ b/core-designsystem/src/main/java/com/hmoa/core_designsystem/component/ErrorUiSetView.kt
@@ -10,7 +10,7 @@ import com.hmoa.core_common.ErrorUiState
 
 
 @Composable
-fun ErrorUiSetView(onConfirmClick: () -> Unit, errorUiState: ErrorUiState, onCloseClick: () -> Unit) {
+fun ErrorUiSetView(onLoginClick: () -> Unit, errorUiState: ErrorUiState, onCloseClick: () -> Unit) {
     var isOpen by remember { mutableStateOf(true) }
     val screenWidth = LocalConfiguration.current.screenWidthDp.dp
 
@@ -26,7 +26,7 @@ fun ErrorUiSetView(onConfirmClick: () -> Unit, errorUiState: ErrorUiState, onClo
                     buttonTitle = "로그인 하러가기",
                     onOkClick = {
                         isOpen = false
-                        onConfirmClick()
+                        onLoginClick()
                     },
                     onCloseClick = {
                         isOpen = false
@@ -43,7 +43,7 @@ fun ErrorUiSetView(onConfirmClick: () -> Unit, errorUiState: ErrorUiState, onClo
                     buttonTitle = "로그인 하러가기",
                     onOkClick = {
                         isOpen = false
-                        onConfirmClick()
+                        onLoginClick()
                     },
                     onCloseClick = {
                         isOpen = false
@@ -60,7 +60,7 @@ fun ErrorUiSetView(onConfirmClick: () -> Unit, errorUiState: ErrorUiState, onClo
                     buttonTitle = "로그인 하러가기",
                     onOkClick = {
                         isOpen = false
-                        onConfirmClick()
+                        onLoginClick()
                     },
                     onCloseClick = {
                         isOpen = false
@@ -74,7 +74,6 @@ fun ErrorUiSetView(onConfirmClick: () -> Unit, errorUiState: ErrorUiState, onClo
                     content = (errorUiState as ErrorUiState.ErrorData).generalError.second ?: "",
                     onDismiss = {
                         isOpen = false
-                        onCloseClick()
                     },
                     modifier = Modifier.wrapContentHeight()
                         .width(screenWidth - 88.dp)

--- a/core-network/src/main/java/com/hmoa/core_network/authentication/AuthAuthenticator.kt
+++ b/core-network/src/main/java/com/hmoa/core_network/authentication/AuthAuthenticator.kt
@@ -6,6 +6,7 @@ import com.hmoa.core_model.request.RememberedLoginRequestDto
 import com.skydoves.sandwich.suspendOnError
 import com.skydoves.sandwich.suspendOnSuccess
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import okhttp3.Request
 import okhttp3.Response
@@ -40,6 +41,10 @@ class AuthAuthenticator @Inject constructor(
                     if (responseBody != null) {
                         val refreshedAuthToken = responseBody.authToken
                         val refreshedRememberToken = responseBody.rememberedToken
+                        launch {
+                            tokenManager.deleteAuthToken()
+                            tokenManager.deleteRememberedToken()
+                        }.join()
                         refreshTokenManager.saveRefreshTokens(refreshedAuthToken, refreshedRememberToken)
                         newRequest = response.request.addRefreshAuthToken(refreshedAuthToken)
                         Log.d("AuthAuthenticator", "토큰 리프레싱 성공")

--- a/core-network/src/main/java/com/hmoa/core_network/di/ServiceModule.kt
+++ b/core-network/src/main/java/com/hmoa/core_network/di/ServiceModule.kt
@@ -47,8 +47,7 @@ object ServiceModule {
     @Singleton
     @Provides
     fun provideHeaderInterceptor(tokenManager: TokenManager): Interceptor {
-        val token = tokenManager.getAuthTokenForHeader()
-
+        var token = tokenManager.getAuthTokenForHeader()
         return Interceptor { chain ->
             with(chain) {
                 val newRequest = request().newBuilder()

--- a/core-network/src/main/java/com/hmoa/core_network/di/ServiceModule.kt
+++ b/core-network/src/main/java/com/hmoa/core_network/di/ServiceModule.kt
@@ -47,7 +47,7 @@ object ServiceModule {
     @Singleton
     @Provides
     fun provideHeaderInterceptor(tokenManager: TokenManager): Interceptor {
-        var token = tokenManager.getAuthTokenForHeader()
+        val token = tokenManager.getAuthTokenForHeader()
         return Interceptor { chain ->
             with(chain) {
                 val newRequest = request().newBuilder()

--- a/feature-community/src/main/java/com/hmoa/feature_community/Screen/CommunityDescriptionPage.kt
+++ b/feature-community/src/main/java/com/hmoa/feature_community/Screen/CommunityDescriptionPage.kt
@@ -158,7 +158,7 @@ fun CommunityDescriptionPage(
         }
         CommunityDescUiState.Error -> {
             ErrorUiSetView(
-                onConfirmClick = onErrorHandleLoginAgain,
+                onLoginClick = onErrorHandleLoginAgain,
                 errorUiState = errState,
                 onCloseClick = onNavBack,
             )

--- a/feature-community/src/main/java/com/hmoa/feature_community/Screen/CommunityHome.kt
+++ b/feature-community/src/main/java/com/hmoa/feature_community/Screen/CommunityHome.kt
@@ -85,7 +85,7 @@ fun CommunityHome(
             }
             is CommunityHomeUiState.Error -> {
                 ErrorUiSetView(
-                    onConfirmClick = onErrorHandleLoginAgain,
+                    onLoginClick = onErrorHandleLoginAgain,
                     errorUiState = errorUiState,
                     onCloseClick = onErrorHandleLoginAgain
                 )

--- a/feature-community/src/main/java/com/hmoa/feature_community/Screen/CommunityPreview.kt
+++ b/feature-community/src/main/java/com/hmoa/feature_community/Screen/CommunityPreview.kt
@@ -135,7 +135,7 @@ fun CommunityPage(
         }
         is CommunityMainUiState.Error -> {
             ErrorUiSetView(
-                onConfirmClick = onErrorHandleLoginAgain,
+                onLoginClick = onErrorHandleLoginAgain,
                 errorUiState = errState,
                 onCloseClick = onErrorHandleLoginAgain
             )

--- a/feature-home/src/main/java/com/hmoa/feature_home/screen/AllPerfumeScreen.kt
+++ b/feature-home/src/main/java/com/hmoa/feature_home/screen/AllPerfumeScreen.kt
@@ -82,7 +82,7 @@ fun AllPerfumeScreen(
 
         AllPerfumeViewModel.AllPerfumeUiState.Error -> {
             ErrorUiSetView(
-                onConfirmClick = { onErrorHandleLoginAgain() },
+                onLoginClick = { onErrorHandleLoginAgain() },
                 errorUiState = errorUiState,
                 onCloseClick = { onNavBack() }
             )

--- a/feature-like/src/main/java/com/hmoa/feature_like/Screen/LikeScreen.kt
+++ b/feature-like/src/main/java/com/hmoa/feature_like/Screen/LikeScreen.kt
@@ -2,18 +2,7 @@ package com.hmoa.feature_like.Screen
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.itemsIndexed
@@ -22,12 +11,7 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
@@ -67,7 +51,7 @@ fun LikeRoute(
         onTypeChanged = { type = it },
         errorUiState = errorUiState,
         onErrorHandleLoginAgain = {
-            if(viewModel.hasToken()){
+            if (viewModel.hasToken()) {
                 onNavHome()
             } else {
                 onErrorHandleLoginAgain()
@@ -103,9 +87,10 @@ fun LikeScreen(
                 NoSavePerfumeScreen()
             }
         }
+
         is LikeUiState.Error -> {
             ErrorUiSetView(
-                onConfirmClick = { onErrorHandleLoginAgain() },
+                onLoginClick = { onErrorHandleLoginAgain() },
                 errorUiState = errorUiState,
                 onCloseClick = onNavHome
             )

--- a/feature-magazine/src/main/java/com/hmoa/feature_magazine/Screen/MagazineDesc.kt
+++ b/feature-magazine/src/main/java/com/hmoa/feature_magazine/Screen/MagazineDesc.kt
@@ -3,21 +3,7 @@ package com.hmoa.feature_magazine.Screen
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
@@ -53,12 +39,12 @@ import com.hmoa.feature_magazine.ViewModel.MagazineDescViewModel
 
 @Composable
 fun MagazineDescRoute(
-    id : Int?,
+    id: Int?,
     onNavBack: () -> Unit,
     onNavLogin: () -> Unit,
-    onNavDesc : (Int) -> Unit,
-    viewModel : MagazineDescViewModel = hiltViewModel()
-){
+    onNavDesc: (Int) -> Unit,
+    viewModel: MagazineDescViewModel = hiltViewModel()
+) {
     viewModel.setId(id)
     val uiState = viewModel.uiState.collectAsStateWithLifecycle()
     val errState = viewModel.errorUiState.collectAsStateWithLifecycle()
@@ -78,19 +64,20 @@ fun MagazineDescRoute(
 
 @Composable
 fun MagazineDescScreen(
-    uiState : MagazineDescUiState,
-    recentMagazines : LazyPagingItems<MagazineSummaryResponseDto>,
-    isLiked : Boolean?,
-    updateMagazineLike : () -> Unit,
-    errState : ErrorUiState,
+    uiState: MagazineDescUiState,
+    recentMagazines: LazyPagingItems<MagazineSummaryResponseDto>,
+    isLiked: Boolean?,
+    updateMagazineLike: () -> Unit,
+    errState: ErrorUiState,
     onNavBack: () -> Unit,
     onNavLogin: () -> Unit,
-    onNavDesc : (Int) -> Unit,
-){
-    when(uiState){
+    onNavDesc: (Int) -> Unit,
+) {
+    when (uiState) {
         MagazineDescUiState.Loading -> {
             AppLoadingScreen()
         }
+
         is MagazineDescUiState.Success -> {
             MagazineDescContent(
                 title = uiState.title,
@@ -108,9 +95,10 @@ fun MagazineDescScreen(
                 onNavDesc = onNavDesc
             )
         }
+
         is MagazineDescUiState.Error -> {
             ErrorUiSetView(
-                onConfirmClick = onNavLogin,
+                onLoginClick = onNavLogin,
                 errorUiState = errState,
                 onCloseClick = onNavBack
             )
@@ -120,26 +108,26 @@ fun MagazineDescScreen(
 
 @Composable
 private fun MagazineDescContent(
-    title : String,
-    releaseDate : String,
-    viewCount : Int,
-    previewImgUrl : String,
-    preview : String,
+    title: String,
+    releaseDate: String,
+    viewCount: Int,
+    previewImgUrl: String,
+    preview: String,
     isLiked: Boolean?,
-    updateMagazineLike : () -> Unit,
-    likeCount : Int,
-    contentList : List<MagazineContentItem>,
-    tagList : List<String>,
-    magazineList : ItemSnapshotList<MagazineSummaryResponseDto>,
-    onNavBack : () -> Unit,
+    updateMagazineLike: () -> Unit,
+    likeCount: Int,
+    contentList: List<MagazineContentItem>,
+    tagList: List<String>,
+    magazineList: ItemSnapshotList<MagazineSummaryResponseDto>,
+    onNavBack: () -> Unit,
     onNavDesc: (Int) -> Unit,
-){
+) {
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()
             .background(color = Color.White)
-    ){
-        item{
+    ) {
+        item {
             TopBar(
                 title = "",
                 navIcon = painterResource(com.hmoa.core_designsystem.R.drawable.ic_back),
@@ -161,11 +149,12 @@ private fun MagazineDescContent(
             HorizontalDivider(
                 Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp),thickness=1.dp,color= CustomColor.gray2)
+                    .padding(horizontal = 16.dp), thickness = 1.dp, color = CustomColor.gray2
+            )
             Spacer(Modifier.height(48.dp))
         }
-        items(contentList){content ->
-            if (content.header != null && content.content != null){
+        items(contentList) { content ->
+            if (content.header != null && content.content != null) {
                 MagazineDescData(
                     header = content.header!!,
                     content = content.content!!,
@@ -173,22 +162,23 @@ private fun MagazineDescContent(
                 )
             }
         }
-        item{
+        item {
             Spacer(Modifier.height(48.dp))
             Tags(tagList = tagList)
             Spacer(Modifier.height(48.dp))
             HorizontalDivider(
                 Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp),thickness=1.dp,color= CustomColor.gray2)
+                    .padding(horizontal = 16.dp), thickness = 1.dp, color = CustomColor.gray2
+            )
             MagazineFooter(
                 isLiked = isLiked ?: false,
                 likeCount = likeCount,
                 updateMagazineLike = updateMagazineLike
             )
             RecentMagazines(
-                magazineList=magazineList,
-                onNavDesc=onNavDesc
+                magazineList = magazineList,
+                onNavDesc = onNavDesc
             )
         }
     }
@@ -196,15 +186,15 @@ private fun MagazineDescContent(
 
 @Composable
 private fun ContentHeader(
-    title : String,
-    releaseDate : String
-){
+    title: String,
+    releaseDate: String
+) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .wrapContentHeight()
             .padding(top = 36.dp, bottom = 52.dp, start = 17.dp)
-    ){
+    ) {
         Text(
             text = title,
             fontSize = 24.sp,
@@ -221,23 +211,23 @@ private fun ContentHeader(
 
 @Composable
 private fun MagazineContent(
-    viewCount : Int,
-    previewImageUrl : String,
-    preview : String,
-){
+    viewCount: Int,
+    previewImageUrl: String,
+    preview: String,
+) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .wrapContentHeight()
             .padding(bottom = 48.dp)
-    ){
+    ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
                 .wrapContentHeight()
                 .padding(start = 17.dp),
             verticalAlignment = Alignment.CenterVertically
-        ){
+        ) {
             Image(
                 painter = painterResource(com.hmoa.core_designsystem.R.drawable.ic_view_number),
                 contentDescription = "View Number"
@@ -254,7 +244,7 @@ private fun MagazineContent(
             modifier = Modifier
                 .fillMaxWidth()
                 .aspectRatio(0.8f)
-        ){
+        ) {
             ImageView(
                 imageUrl = previewImageUrl,
                 width = 1f,
@@ -278,21 +268,21 @@ private fun MagazineContent(
 
 @Composable
 private fun MagazineDescData(
-    header : String,
-    content : String,
-    image : String?
-){
+    header: String,
+    content: String,
+    image: String?
+) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .wrapContentHeight()
             .padding(horizontal = 16.dp)
-    ){
-        if(image != null){
+    ) {
+        if (image != null) {
             Box(
                 modifier = Modifier.fillMaxWidth()
                     .aspectRatio(0.8f)
-            ){
+            ) {
                 ImageView(
                     imageUrl = image,
                     width = 1f,
@@ -321,8 +311,8 @@ private fun MagazineDescData(
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun Tags(
-    tagList : List<String>
-){
+    tagList: List<String>
+) {
     FlowRow(
         modifier = Modifier
             .fillMaxWidth()
@@ -330,8 +320,8 @@ private fun Tags(
             .padding(horizontal = 17.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp)
-    ){
-        tagList.forEach{ tag ->
+    ) {
+        tagList.forEach { tag ->
             MagazineTag(tag = tag)
         }
     }
@@ -340,16 +330,16 @@ private fun Tags(
 @Composable
 private fun MagazineFooter(
     isLiked: Boolean,
-    likeCount : Int,
-    updateMagazineLike : () -> Unit,
-){
+    likeCount: Int,
+    updateMagazineLike: () -> Unit,
+) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .height(170.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.Center
-    ){
+    ) {
         Text(
             text = "매거진이 유용한 정보였다면",
             fontSize = 16.sp,
@@ -359,14 +349,14 @@ private fun MagazineFooter(
         Column(
             modifier = Modifier.wrapContentSize(),
             horizontalAlignment = Alignment.CenterHorizontally
-        ){
+        ) {
             IconButton(
                 onClick = updateMagazineLike
-            ){
+            ) {
                 Icon(
                     painter = painterResource(com.hmoa.core_designsystem.R.drawable.ic_thumb_up),
                     contentDescription = "Like",
-                    tint = if(isLiked) CustomColor.gray4 else CustomColor.gray2
+                    tint = if (isLiked) CustomColor.gray4 else CustomColor.gray2
                 )
             }
             Spacer(Modifier.height(12.dp))
@@ -381,16 +371,16 @@ private fun MagazineFooter(
 
 @Composable
 private fun RecentMagazines(
-    magazineList : ItemSnapshotList<MagazineSummaryResponseDto>,
+    magazineList: ItemSnapshotList<MagazineSummaryResponseDto>,
     onNavDesc: (Int) -> Unit
-){
+) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .height(358.dp)
             .background(color = Color.Black)
             .padding(top = 32.dp)
-    ){
+    ) {
         Text(
             modifier = Modifier.padding(start = 16.dp),
             text = "최신 매거진",
@@ -399,22 +389,22 @@ private fun RecentMagazines(
         )
         Spacer(Modifier.height(16.dp))
         HorizontalDivider(
-            modifier= Modifier
+            modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
-            thickness=0.5.dp,
-            color=CustomColor.gray2
+            thickness = 0.5.dp,
+            color = CustomColor.gray2
         )
         Spacer(Modifier.height(16.dp))
         LazyRow(
             horizontalArrangement = Arrangement.spacedBy(8.dp)
-        ){
-            items(magazineList){magazine ->
-                if (magazine!=null){
+        ) {
+            items(magazineList) { magazine ->
+                if (magazine != null) {
                     RecentMagazineItem(
                         previewImageUrl = magazine.previewImgUrl,
                         title = magazine.title,
-                        onNavDesc = {onNavDesc(magazine.magazineId)}
+                        onNavDesc = { onNavDesc(magazine.magazineId) }
                     )
                 }
             }
@@ -424,23 +414,23 @@ private fun RecentMagazines(
 
 @Composable
 private fun RecentMagazineItem(
-    previewImageUrl : String,
-    title : String,
+    previewImageUrl: String,
+    title: String,
     onNavDesc: () -> Unit,
-){
+) {
     Column(
         modifier = Modifier
             .width(132.dp)
             .wrapContentHeight()
-            .clickable{
+            .clickable {
                 onNavDesc()
             }
-    ){
+    ) {
         Box(
             modifier = Modifier
                 .height(184.dp)
                 .width(132.dp)
-        ){
+        ) {
             ImageView(
                 imageUrl = previewImageUrl,
                 width = 1f,

--- a/feature-magazine/src/main/java/com/hmoa/feature_magazine/Screen/MagazineMain.kt
+++ b/feature-magazine/src/main/java/com/hmoa/feature_magazine/Screen/MagazineMain.kt
@@ -4,20 +4,7 @@ import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
@@ -52,12 +39,12 @@ import com.hmoa.feature_magazine.ViewModel.MagazineMainViewModel
 
 @Composable
 fun MagazineMainRoute(
-    onNavHome : () -> Unit,
-    onNavPerfumeDesc : (Int) -> Unit,
-    onNavCommunityDesc : (Int) -> Unit,
-    onNavMagazineDesc : (Int) -> Unit,
-    viewModel : MagazineMainViewModel = hiltViewModel()
-){
+    onNavHome: () -> Unit,
+    onNavPerfumeDesc: (Int) -> Unit,
+    onNavCommunityDesc: (Int) -> Unit,
+    onNavMagazineDesc: (Int) -> Unit,
+    viewModel: MagazineMainViewModel = hiltViewModel()
+) {
     val uiState = viewModel.uiState.collectAsStateWithLifecycle()
     val errorState = viewModel.errorUiState.collectAsStateWithLifecycle()
     val magazineList = viewModel.magazinePagingSource().collectAsLazyPagingItems()
@@ -75,18 +62,19 @@ fun MagazineMainRoute(
 
 @Composable
 fun MagazineMainScreen(
-    uiState : MagazineMainUiState,
-    errorState : ErrorUiState,
-    magazineList : LazyPagingItems<MagazineSummaryResponseDto>,
-    onNavHome : () -> Unit,
+    uiState: MagazineMainUiState,
+    errorState: ErrorUiState,
+    magazineList: LazyPagingItems<MagazineSummaryResponseDto>,
+    onNavHome: () -> Unit,
     onNavPerfumeDesc: (Int) -> Unit,
     onNavCommunityDesc: (Int) -> Unit,
     onNavMagazineDesc: (Int) -> Unit
-){
-    when(uiState){
+) {
+    when (uiState) {
         MagazineMainUiState.Loading -> {
             AppLoadingScreen()
         }
+
         is MagazineMainUiState.MagazineMain -> {
             MagazineFullContent(
                 magazineList = magazineList.itemSnapshotList,
@@ -97,9 +85,10 @@ fun MagazineMainScreen(
                 onNavMagazineDesc = onNavMagazineDesc
             )
         }
+
         is MagazineMainUiState.Error -> {
             ErrorUiSetView(
-                onConfirmClick = { onNavHome() },
+                onLoginClick = { onNavHome() },
                 errorUiState = errorState,
                 onCloseClick = { onNavHome() }
             )
@@ -109,21 +98,21 @@ fun MagazineMainScreen(
 
 @Composable
 private fun MagazineFullContent(
-    magazineList : ItemSnapshotList<MagazineSummaryResponseDto>,
-    perfumeList : RecentPerfumeResponseDto,
-    reviewList : MagazineTastingCommentResponseDto,
+    magazineList: ItemSnapshotList<MagazineSummaryResponseDto>,
+    perfumeList: RecentPerfumeResponseDto,
+    reviewList: MagazineTastingCommentResponseDto,
     onNavPerfumeDesc: (Int) -> Unit,
     onNavCommunityDesc: (Int) -> Unit,
     onNavMagazineDesc: (Int) -> Unit
-){
-    if (magazineList.isNotEmpty()){
+) {
+    if (magazineList.isNotEmpty()) {
         val firstMagazine = magazineList[0]!!
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize(),
             verticalArrangement = Arrangement.spacedBy(56.dp)
-        ){
-            item{
+        ) {
+            item {
                 MagazineTitleBox(
                     imageUrl = firstMagazine.previewImgUrl,
                     title = firstMagazine.title,
@@ -143,8 +132,8 @@ private fun MagazineFullContent(
                 MagazineHeader()
                 Spacer(Modifier.height(24.dp))
             }
-            items(magazineList){magazine ->
-                if (magazine != null){
+            items(magazineList) { magazine ->
+                if (magazine != null) {
                     MagazineContent(
                         imageUrl = magazine.previewImgUrl,
                         title = magazine.title,
@@ -162,16 +151,16 @@ private fun MagazineFullContent(
 
 @Composable
 private fun MagazineTitleBox(
-    imageUrl : String,
-    title : String,
-    preview : String,
-){
+    imageUrl: String,
+    title: String,
+    preview: String,
+) {
     Box(
         modifier = Modifier
             .fillMaxWidth()
             .height(513.dp),
         contentAlignment = Alignment.Center
-    ){
+    ) {
         ImageView(
             imageUrl = imageUrl,
             width = 1f,
@@ -187,7 +176,7 @@ private fun MagazineTitleBox(
                 .padding(horizontal = 16.dp)
                 .padding(bottom = 22.dp)
                 .background(color = Color.Transparent)
-        ){
+        ) {
             TopBar(
                 title = "Magazine",
                 titleColor = Color.White
@@ -196,7 +185,7 @@ private fun MagazineTitleBox(
                 modifier = Modifier
                     .fillMaxSize()
                     .aspectRatio(1f)
-            ){
+            ) {
                 ImageView(
                     imageUrl = imageUrl,
                     width = 1f,
@@ -212,7 +201,7 @@ private fun MagazineTitleBox(
                         .padding(horizontal = 24.dp),
                     verticalArrangement = Arrangement.Bottom,
                     horizontalAlignment = Alignment.CenterHorizontally
-                ){
+                ) {
                     Text(
                         text = title,
                         fontSize = 24.sp,
@@ -233,14 +222,14 @@ private fun MagazineTitleBox(
 
 @Composable
 private fun ReleasePerfumeList(
-    perfumeList : RecentPerfumeResponseDto,
+    perfumeList: RecentPerfumeResponseDto,
     onNavPerfumeDesc: (Int) -> Unit
-){
+) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .wrapContentHeight()
-    ){
+    ) {
         Text(
             modifier = Modifier.padding(16.dp),
             text = "출시 향수",
@@ -258,8 +247,8 @@ private fun ReleasePerfumeList(
         LazyRow(
             modifier = Modifier.padding(16.dp),
             horizontalArrangement = Arrangement.spacedBy(8.dp)
-        ){
-            items(perfumeList){perfume ->
+        ) {
+            items(perfumeList) { perfume ->
                 PerfumeDescItem(
                     imageUrl = perfume.perfumeImgUrl,
                     brandName = perfume.brandName,
@@ -274,10 +263,10 @@ private fun ReleasePerfumeList(
 
 @Composable
 private fun Top10Reviews(
-    reviews : MagazineTastingCommentResponseDto,
+    reviews: MagazineTastingCommentResponseDto,
     onNavCommunityDesc: (Int) -> Unit
-){
-    Column{
+) {
+    Column {
         Text(
             modifier = Modifier.padding(start = 16.dp),
             text = "TOP 10 시향기",
@@ -295,8 +284,8 @@ private fun Top10Reviews(
         LazyRow(
             modifier = Modifier.padding(horizontal = 16.dp),
             horizontalArrangement = Arrangement.spacedBy(8.dp)
-        ){
-            items(reviews){review ->
+        ) {
+            items(reviews) { review ->
                 ReviewContent(
                     title = review.title,
                     profileImg = review.profileImg,
@@ -310,13 +299,13 @@ private fun Top10Reviews(
 }
 
 @Composable
-private fun MagazineHeader(){
+private fun MagazineHeader() {
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .wrapContentHeight()
             .padding(start = 16.dp)
-    ){
+    ) {
         Text(
             text = "HMOA\nNEWS / 매거진",
             fontSize = 20.sp,
@@ -324,30 +313,31 @@ private fun MagazineHeader(){
         )
         Spacer(Modifier.height(12.dp))
         Text(
-            text="향모아가 전하는 향수 트렌드 이슈",
-            fontSize=14.sp,
+            text = "향모아가 전하는 향수 트렌드 이슈",
+            fontSize = 14.sp,
             color = Color.Black
         )
     }
 }
+
 @Composable
 private fun MagazineContent(
-    imageUrl : String,
-    title : String,
-    preview : String,
+    imageUrl: String,
+    title: String,
+    preview: String,
     onNavMagazineDesc: () -> Unit
-){
+) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .clickable { onNavMagazineDesc() }
             .padding(horizontal = 16.dp)
-    ){
+    ) {
         Box(
             modifier = Modifier
                 .fillMaxWidth()
                 .aspectRatio(1f)
-        ){
+        ) {
             ImageView(
                 imageUrl = imageUrl,
                 width = 1f,
@@ -373,20 +363,20 @@ private fun MagazineContent(
 
 @Composable
 private fun PerfumeDescItem(
-    imageUrl : String,
-    brandName : String,
-    perfumeName : String,
-    releaseDate : String,
+    imageUrl: String,
+    brandName: String,
+    perfumeName: String,
+    releaseDate: String,
     onNavPerfumeDesc: () -> Unit
-){
+) {
     Column(
-        modifier = Modifier.clickable{
+        modifier = Modifier.clickable {
             onNavPerfumeDesc()
         }
     ) {
         Box(
             modifier = Modifier.size(155.dp)
-        ){
+        ) {
             ImageView(
                 imageUrl = imageUrl,
                 width = 1f,
@@ -418,12 +408,12 @@ private fun PerfumeDescItem(
 
 @Composable
 private fun ReviewContent(
-    title : String,
-    profileImg : String,
-    nickname : String,
-    content : String,
+    title: String,
+    profileImg: String,
+    nickname: String,
+    content: String,
     onNavCommunityDesc: () -> Unit
-){
+) {
     Column(
         modifier = Modifier
             .width(296.dp)
@@ -435,7 +425,7 @@ private fun ReviewContent(
             }
             .padding(horizontal = 20.dp)
             .padding(bottom = 20.dp, top = 24.dp)
-    ){
+    ) {
         Text(
             text = title,
             fontSize = 16.sp,
@@ -447,7 +437,7 @@ private fun ReviewContent(
         Row(
             modifier = Modifier.wrapContentSize(),
             verticalAlignment = Alignment.CenterVertically
-        ){
+        ) {
             CircleImageView(
                 imgUrl = profileImg,
                 width = 20,

--- a/feature-perfume/src/main/java/com/hmoa/feature_perfume/screen/PerfumeScreen.kt
+++ b/feature-perfume/src/main/java/com/hmoa/feature_perfume/screen/PerfumeScreen.kt
@@ -90,7 +90,7 @@ fun PerfumeScreen(
     val errorUiState by viewModel.errorUiState.collectAsStateWithLifecycle()
 
     ErrorUiSetView(
-        onConfirmClick = { onErrorHandleLoginAgain() },
+        onLoginClick = { onErrorHandleLoginAgain() },
         errorUiState = errorUiState,
         onCloseClick = { onBackClick() }
     )

--- a/feature-userInfo/src/main/java/com/hmoa/feature_userinfo/Screen/MyCommentPage.kt
+++ b/feature-userInfo/src/main/java/com/hmoa/feature_userinfo/Screen/MyCommentPage.kt
@@ -1,15 +1,7 @@
 package com.example.userinfo
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
@@ -39,7 +31,7 @@ import com.hmoa.feature_userinfo.viewModel.CommentViewModel
 fun MyCommentRoute(
     onNavBack: () -> Unit,
     onNavCommunity: (Int) -> Unit,
-    onNavPerfume : (Int) -> Unit,
+    onNavPerfume: (Int) -> Unit,
     viewModel: CommentViewModel = hiltViewModel()
 ) {
     //comment list
@@ -53,7 +45,7 @@ fun MyCommentRoute(
         type = type.value,
         onNavBack = onNavBack,
         onNavParent = {
-            if (type.value == MyPageCategory.향수.name){
+            if (type.value == MyPageCategory.향수.name) {
                 onNavPerfume(it)
             } else {
                 onNavCommunity(it)
@@ -68,16 +60,18 @@ fun MyCommentRoute(
 @Composable
 fun MyCommentPage(
     uiState: CommentUiState,
-    errState : ErrorUiState,
+    errState: ErrorUiState,
     type: String,
     onNavBack: () -> Unit,
-    onNavParent : (Int) -> Unit,
+    onNavParent: (Int) -> Unit,
     onTypeChanged: (String) -> Unit
 ) {
     when (uiState) {
-        CommentUiState.Loading -> {9
+        CommentUiState.Loading -> {
+            9
             AppLoadingScreen()
         }
+
         is CommentUiState.Comments -> {
             val comments = uiState.comments.collectAsLazyPagingItems().itemSnapshotList
             MyCommentContent(
@@ -88,9 +82,10 @@ fun MyCommentPage(
                 onNavParent = onNavParent
             )
         }
+
         CommentUiState.Error -> {
             ErrorUiSetView(
-                onConfirmClick = onNavBack,
+                onLoginClick = onNavBack,
                 errorUiState = errState,
                 onCloseClick = onNavBack
             )

--- a/feature-userInfo/src/main/java/com/hmoa/feature_userinfo/Screen/MyFavoriteCommentPage.kt
+++ b/feature-userInfo/src/main/java/com/hmoa/feature_userinfo/Screen/MyFavoriteCommentPage.kt
@@ -1,15 +1,7 @@
 package com.hmoa.feature_userinfo
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
@@ -37,7 +29,7 @@ import com.hmoa.core_model.response.CommunityCommentDefaultResponseDto
 fun MyFavoriteCommentRoute(
     onNavBack: () -> Unit,
     onNavCommunity: (Int) -> Unit,
-    onNavPerfume : (Int) -> Unit,
+    onNavPerfume: (Int) -> Unit,
     viewModel: FavoriteCommentViewModel = hiltViewModel()
 ) {
     //comment list
@@ -52,7 +44,7 @@ fun MyFavoriteCommentRoute(
         onTypeChanged = { viewModel.changeType(it) },
         onNavBack = onNavBack,
         onNavParent = {
-            if (type.value == MyPageCategory.향수.name){
+            if (type.value == MyPageCategory.향수.name) {
                 onNavPerfume(it)
             } else {
                 onNavCommunity(it)
@@ -66,7 +58,7 @@ fun MyFavoriteCommentPage(
     onNavBack: () -> Unit,
     onNavParent: (Int) -> Unit,
     uiState: FavoriteCommentUiState,
-    errState : ErrorUiState,
+    errState: ErrorUiState,
     commentType: String,
     onTypeChanged: (String) -> Unit,
 ) {
@@ -74,6 +66,7 @@ fun MyFavoriteCommentPage(
         FavoriteCommentUiState.Loading -> {
             AppLoadingScreen()
         }
+
         is FavoriteCommentUiState.Comments -> {
             val comments = uiState.comments.collectAsLazyPagingItems()
             FavoriteCommentContent(
@@ -84,13 +77,15 @@ fun MyFavoriteCommentPage(
                 onNavParent = onNavParent
             )
         }
+
         FavoriteCommentUiState.Error -> {
             ErrorUiSetView(
-                onConfirmClick = onNavBack,
+                onLoginClick = onNavBack,
                 errorUiState = errState,
                 onCloseClick = onNavBack
             )
         }
+
         else -> {}
     }
 }

--- a/feature-userInfo/src/main/java/com/hmoa/feature_userinfo/Screen/MyPage.kt
+++ b/feature-userInfo/src/main/java/com/hmoa/feature_userinfo/Screen/MyPage.kt
@@ -6,15 +6,7 @@ import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
@@ -131,6 +123,7 @@ fun MyPage(
         UserInfoUiState.Loading -> {
             AppLoadingScreen()
         }
+
         is UserInfoUiState.User -> {
             MyPageContent(
                 profile = uiState.profile,
@@ -147,13 +140,15 @@ fun MyPage(
                 onNavManageMyInfo = onNavManageMyInfo,
             )
         }
+
         UserInfoUiState.Error -> {
             ErrorUiSetView(
-                onConfirmClick = { onErrorHandleLoginAgain() },
+                onLoginClick = { onErrorHandleLoginAgain() },
                 errorUiState = errorUiState,
                 onCloseClick = { onBackClick() }
             )
         }
+
         else -> {}
     }
 }
@@ -167,14 +162,14 @@ private fun MyPageContent(
     doOpenLicense: () -> Unit,
     openPrivacyPolicyLink: () -> Unit,
     onDelAccount: () -> Unit,
-    onNavMyPerfume : () -> Unit,
+    onNavMyPerfume: () -> Unit,
     onNavKakaoChat: () -> Unit,
     onNavEditProfile: () -> Unit,
     onNavMyActivity: () -> Unit,
     onNavManageMyInfo: () -> Unit,
 ) {
     val columnInfo = listOf(
-        ColumnData("나의 향수") {onNavMyPerfume() },
+        ColumnData("나의 향수") { onNavMyPerfume() },
         ColumnData("내 활동") { onNavMyActivity() },
         ColumnData("내 정보관리") { onNavManageMyInfo() },
         ColumnData("오픈소스라이센스") { doOpenLicense() },
@@ -191,7 +186,7 @@ private fun MyPageContent(
             .fillMaxSize()
             .background(color = Color.White)
     ) {
-        item{
+        item {
             TopBar(title = "마이페이지")
             UserProfileInfo(
                 profile = profile,

--- a/feature-userInfo/src/main/java/com/hmoa/feature_userinfo/Screen/MyPage.kt
+++ b/feature-userInfo/src/main/java/com/hmoa/feature_userinfo/Screen/MyPage.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -41,6 +42,8 @@ import com.hmoa.feature_userinfo.BuildConfig
 import com.hmoa.feature_userinfo.ColumnData
 import com.hmoa.feature_userinfo.NoAuthMyPage
 import com.kakao.sdk.talk.TalkApiClient
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 const val APP_VERSION = "1.1.0"
 
@@ -68,14 +71,17 @@ internal fun MyPageRoute(
     val launcher = rememberLauncherForActivityResult(contract = ActivityResultContracts.StartActivityForResult()) {
     }
     val privacyPolicyIntent = remember { Intent(Intent.ACTION_VIEW, Uri.parse(BuildConfig.PRIVACY_POLICY_URI)) }
+    val scope = rememberCoroutineScope()
     if (isLogin.value) {
         //로그인 분기 처리 (토큰 확인)
         MyPage(
             uiState = uiState.value,
             errorUiState = errorUiState,
             logoutEvent = {
-                viewModel.logout()
-                onNavLogin()
+                scope.launch {
+                    launch { viewModel.logout() }.join()
+                    onNavLogin()
+                }
             },
             doOpenLicense = {
                 launcher.launch(Intent(context, OssLicensesMenuActivity::class.java))
@@ -83,8 +89,10 @@ internal fun MyPageRoute(
             },
             openPrivacyPolicyLink = { context.startActivity(privacyPolicyIntent) },
             onDelAccount = {
-                viewModel.delAccount()
-                onNavLogin()
+                scope.launch {
+                    launch { viewModel.delAccount() }.join()
+                    onNavLogin()
+                }
             },
             onNavKakaoChat = navKakao,
             onNavMyPerfume = onNavMyPerfume,

--- a/feature-userInfo/src/main/java/com/hmoa/feature_userinfo/viewModel/MyPageViewModel.kt
+++ b/feature-userInfo/src/main/java/com/hmoa/feature_userinfo/viewModel/MyPageViewModel.kt
@@ -29,17 +29,20 @@ class MyPageViewModel @Inject constructor(
     private var expiredTokenErrorState = MutableStateFlow<Boolean>(false)
     private var wrongTypeTokenErrorState = MutableStateFlow<Boolean>(false)
     private var unLoginedErrorState = MutableStateFlow<Boolean>(false)
+    private var memberNotFoundErrorState = MutableStateFlow<Boolean>(false)
     private var generalErrorState = MutableStateFlow<Pair<Boolean, String?>>(Pair(false, null))
     val errorUiState: StateFlow<ErrorUiState> = combine(
         expiredTokenErrorState,
         wrongTypeTokenErrorState,
         unLoginedErrorState,
+        memberNotFoundErrorState,
         generalErrorState
-    ) { expiredTokenError, wrongTypeTokenError, unknownError, generalError ->
+    ) { expiredTokenError, wrongTypeTokenError, unknownError, memberNotFoundError, generalError ->
         ErrorUiState.ErrorData(
             expiredTokenError = expiredTokenError,
             wrongTypeTokenError = wrongTypeTokenError,
             unknownError = unknownError,
+            memberNotFoundError = memberNotFoundError,
             generalError = generalError
         )
     }.stateIn(
@@ -74,6 +77,7 @@ class MyPageViewModel @Inject constructor(
                     ErrorMessageType.EXPIRED_TOKEN.message -> expiredTokenErrorState.update { true }
                     ErrorMessageType.WRONG_TYPE_TOKEN.message -> wrongTypeTokenErrorState.update { true }
                     ErrorMessageType.UNKNOWN_ERROR.message -> unLoginedErrorState.update { true }
+                    ErrorMessageType.MEMBER_NOT_FOUND.message -> memberNotFoundErrorState.update { true }
                     else -> generalErrorState.update { Pair(true, result.exception.message) }
                 }
                 UserInfoUiState.Error

--- a/feature-userInfo/src/main/java/com/hmoa/feature_userinfo/viewModel/MyPageViewModel.kt
+++ b/feature-userInfo/src/main/java/com/hmoa/feature_userinfo/viewModel/MyPageViewModel.kt
@@ -11,6 +11,7 @@ import com.hmoa.core_domain.repository.LoginRepository
 import com.hmoa.core_domain.repository.MemberRepository
 import com.hmoa.core_domain.usecase.GetMyUserInfoUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -90,7 +91,7 @@ class MyPageViewModel @Inject constructor(
     )
 
     private fun getAuthToken() {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             loginRepository.getAuthToken().onEmpty { }.collectLatest {
                 authTokenState.value = it
             }
@@ -98,8 +99,8 @@ class MyPageViewModel @Inject constructor(
     }
 
     //로그아웃
-    fun logout() {
-        viewModelScope.launch {
+    suspend fun logout() {
+        viewModelScope.launch(Dispatchers.IO) {
             fcmRepository.deleteRemoteFcmToken()
             fcmRepository.deleteLocalFcmToken()
             loginRepository.deleteAuthToken()
@@ -109,7 +110,7 @@ class MyPageViewModel @Inject constructor(
 
     //계정 삭제
     fun delAccount() {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             fcmRepository.deleteRemoteFcmToken()
             fcmRepository.deleteLocalFcmToken()
             try {


### PR DESCRIPTION
@uselessnaming 
# 금일 1.0.0 (15) 버전 구글 재제출
8/5(월) 재제출 내용은 아래와 같이 해서 1.0.0(14)로 냈었습니다
1.토큰 리프레싱 후 기존 토큰을 삭제하는 코드 추가
2.일반 에러 다이얼로그 네비게이팅에 back 네비게이팅 동작 삭제

하지만 금일 8/7(수)에 다시 에러메세지를 제대로 고칠 수 있게 되어서 아래 내용 수정 후 1.0.0(15)로 재제출 했습니다.🌝
1. 에러처리 컴포넌트에 {"code":"MEMBER_NOT_FOUND", "message":"등록된 멤버가 없습니다."} 해당 에러 타입에 대한 다이얼로그 지정이 되어있지 않아서 이 부분을 추가했습니다 :) 

MEMBER_NOT_FOUND는 다른 에러메세지들보다 나중에 추가되었었는데 데이터 클래스부분에서만 추가되고 컴포넌트 단에서는 누락이 되어서 그랬던 걸로 확인이 되었습니다..!🤗

근본적으로 MEMBER_NOT_FOUND가 나오는 상황은 좋지 않긴 하지만, 일단 다시 에러메세지 오류는 해결한 거 같습니다😋