### PR TITLE
Hotfix/error message2 에러메세지 데이터클래스 캐스팅 오류 구문 제거

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
         applicationId = "com.hmoa.app"
         minSdk = 26
         targetSdk = 33
-        versionCode = 17
+        versionCode = 18
         versionName = "1.0.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/core-designsystem/src/main/java/com/hmoa/core_designsystem/component/ErrorUiSetView.kt
+++ b/core-designsystem/src/main/java/com/hmoa/core_designsystem/component/ErrorUiSetView.kt
@@ -1,6 +1,5 @@
 package com.hmoa.core_designsystem.component
 
-import android.util.Log
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.runtime.*
@@ -15,12 +14,6 @@ fun ErrorUiSetView(onLoginClick: () -> Unit, errorUiState: ErrorUiState, onClose
     var isOpen by remember { mutableStateOf(true) }
     val screenWidth = LocalConfiguration.current.screenWidthDp.dp
 
-    LaunchedEffect(errorUiState) {
-        Log.d(
-            "MyPageViewModel",
-            "errorUiState.memberNotFoundError:${(errorUiState as ErrorUiState.ErrorData).memberNotFoundError}"
-        )
-    }
     when (errorUiState) {
         is ErrorUiState.ErrorData -> {
             if (errorUiState.expiredTokenError) {

--- a/feature-userInfo/src/main/java/com/hmoa/feature_userinfo/Screen/MyPage.kt
+++ b/feature-userInfo/src/main/java/com/hmoa/feature_userinfo/Screen/MyPage.kt
@@ -181,7 +181,7 @@ private fun MyPageContent(
         ColumnData("내 활동") { onNavMyActivity() },
         ColumnData("내 정보관리") { onNavManageMyInfo() },
         ColumnData("오픈소스라이센스") { doOpenLicense() },
-        ColumnData("이용 약관") { },
+        //ColumnData("이용 약관") { },
         ColumnData("개인정보 처리방침") { openPrivacyPolicyLink() },
         ColumnData("버전 정보 ${APP_VERSION}") {},
         ColumnData("1대1 문의") { onNavKakaoChat() },


### PR DESCRIPTION
@uselessnaming 
# google play aar 오류내용 수정
aar에서 보고된 오류는 모두 아래와 같은 내용이었습니다. 
`java.lang.ClassCastException: com.hmoa.core_common.ErrorUiState$Loading cannot be cast to com.hmoa.core_common.ErrorUiState$ErrorData`

MemberNotFoundError는 ErrorUiState 인터페이스에서
 유일하게 nullable합니다.
```kotlin
sealed interface ErrorUiState {
    data class ErrorData(
        val expiredTokenError: Boolean,
        val wrongTypeTokenError: Boolean,
        val unknownError: Boolean,
        val memberNotFoundError: Boolean? = null,
        val generalError: Pair<Boolean, String?>
    ) : ErrorUiState

    data object Loading : ErrorUiState
}
```

아래처럼 며칠 전에 ErrorUiSetView에서 디버깅용으로 추가해두었던 구문이 있습니다. memberNotFoundError가 null이 아닌 화면은 멀쩡하지만, null인 화면에서 이 Log구문에 접근하면 캐스팅 실패가 일어날 수 있고, 그래서 에러처리 컴포넌트가 있는 향수페이지로 넘어가자마자 즉시 앱이 튕기는 거였습니다. 그래서 지금은 삭제했습니다.
```kotlin
    LaunchedEffect(errorUiState) {
        Log.d(
            "MyPageViewModel",
            "errorUiState.memberNotFoundError:${(errorUiState as ErrorUiState.ErrorData).memberNotFoundError}"
        )
    }
```
# 추가 변경사항
마이페이지에서 서비스 이용약관은 아직 내용도 없고 네비게이팅 효과도 없어서 Broken Functionality Policy 위반사항으로 보일 수 있어서 지웠습니다. 아까 말씀드린 알림 스위치도 같은 맥락이었습니다!