### PR TITLE
Feature/hbti lyi 1차 명세 HBTI 기능 수정

### DIFF
--- a/core-designsystem/src/main/java/com/hmoa/core_designsystem/component/SurveyOptionList.kt
+++ b/core-designsystem/src/main/java/com/hmoa/core_designsystem/component/SurveyOptionList.kt
@@ -21,30 +21,31 @@ import com.hmoa.core_designsystem.theme.pretendard
 
 @Composable
 fun SurveyOptionList(
-    initValue: String? = null,
+    answerIds: List<Int>,
     surveyOptions: List<String>,
-    onButtonClick: (optionIndex: Int) -> Unit
+    surveyOptionIds: List<Int>,
+    onButtonClick: (optionIndex: Int, isGoToSelectedState: Boolean) -> Unit
 ) {
-    val surveyOptions = surveyOptions
-    val (selectedOption, onOptionSelected) = remember {
-        val idx = if (initValue == null) 0 else surveyOptions.indexOf(initValue)
-        mutableStateOf(surveyOptions[idx])
+    val selectedOptions = remember {
+        answerIds.map { answerId ->
+            val idx = surveyOptionIds.indexOf(answerId)
+            mutableStateOf(surveyOptions[idx])
+        }
     }
     val scrollState = rememberScrollState()
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Top,
-        modifier = Modifier.fillMaxHeight(0.7f).verticalScroll(scrollState).background(color =Color.White)
+        modifier = Modifier.fillMaxHeight(0.7f).verticalScroll(scrollState).background(color = Color.White)
     ) {
         surveyOptions.forEachIndexed { index, it ->
             Column(modifier = Modifier.padding(bottom = 16.dp)) {
                 SurveyOptionItem(
                     text = it,
                     onClick = {
-                        onOptionSelected(it)
-                        onButtonClick(index)
+                        onButtonClick(index, !(it == selectedOptions[index].value))
                     },
-                    isSelected = (it == selectedOption)
+                    isSelected = if (answerIds.isNotEmpty()) (it == selectedOptions[index].value) else false
                 )
             }
         }
@@ -86,8 +87,11 @@ fun SurveyOptionItem(text: String, onClick: () -> Unit, isSelected: Boolean) {
 @Composable
 fun SurveyOptionItemPreview() {
     val seasons = listOf("싱그럽고 활기찬 '봄'", "화창하고 에너지 넘치는 '여름'", "우아하고 고요한 분위기의 '가을'", "차가움과 아늑함이 공존하는 '겨울'")
-    Column(verticalArrangement = Arrangement.Bottom, modifier = Modifier.fillMaxHeight(1f).background(color = Color.Yellow)) {
-        SurveyOptionList(null, seasons, {})
+    Column(
+        verticalArrangement = Arrangement.Bottom,
+        modifier = Modifier.fillMaxHeight(1f)
+    ) {
+        SurveyOptionList(listOf(5, 1), seasons, listOf(5, 1, 2, 3), { idx, isGoTo -> })
         Button(
             isEnabled = true,
             btnText = "다음",

--- a/core-designsystem/src/main/java/com/hmoa/core_designsystem/component/SurveyOptionList.kt
+++ b/core-designsystem/src/main/java/com/hmoa/core_designsystem/component/SurveyOptionList.kt
@@ -1,10 +1,12 @@
 package com.hmoa.core_designsystem.component
 
+import android.util.Log
 import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -26,12 +28,38 @@ fun SurveyOptionList(
     surveyOptionIds: List<Int>,
     onButtonClick: (optionIndex: Int, isGoToSelectedState: Boolean) -> Unit
 ) {
-    val selectedOptions = remember {
-        answerIds.map { answerId ->
-            val idx = surveyOptionIds.indexOf(answerId)
-            mutableStateOf(surveyOptions[idx])
+    val selectedOptionIds = remember {
+        surveyOptionIds.mapIndexed { index, it ->
+            if (it in answerIds) {
+                mutableStateOf(it)
+            } else {
+                mutableStateOf(null)
+            }
         }
     }
+
+    val selectedStates = remember {
+        surveyOptionIds.mapIndexed { index, it ->
+            if (it in answerIds) {
+                mutableStateOf(true)
+            } else {
+                mutableStateOf(false)
+            }
+        }
+    }.toMutableList()
+
+    fun immediateSelectedStateChange(index: Int){
+        selectedStates[index].value = !selectedStates[index].value
+    }
+
+    LaunchedEffect(answerIds) {
+        Log.d("answerIds", "${answerIds}")
+    }
+
+    LaunchedEffect(selectedOptionIds) {
+        Log.d("SurveyOptionList", "${selectedOptionIds}")
+    }
+
     val scrollState = rememberScrollState()
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -41,11 +69,13 @@ fun SurveyOptionList(
         surveyOptions.forEachIndexed { index, it ->
             Column(modifier = Modifier.padding(bottom = 16.dp)) {
                 SurveyOptionItem(
-                    text = it,
+                    text = surveyOptions[index],
                     onClick = {
-                        onButtonClick(index, !(it == selectedOptions[index].value))
+                        val state = selectedStates[index].value
+                        immediateSelectedStateChange(index)
+                        onButtonClick(index, !state)
                     },
-                    isSelected = if (answerIds.isNotEmpty()) (it == selectedOptions[index].value) else false
+                    isSelected = selectedStates[index].value
                 )
             }
         }

--- a/core-model/src/main/java/com/hmoa/core_model/data/HbtiQuestionItem.kt
+++ b/core-model/src/main/java/com/hmoa/core_model/data/HbtiQuestionItem.kt
@@ -1,0 +1,10 @@
+package com.hmoa.core_model.data
+
+data class HbtiQuestionItem(
+    val questionId: Int,
+    val questionContent:String,
+    val optionIds: List<Int>,
+    val optionContents: List<String>,
+    val isMultipleChoice: Boolean,
+    val selectedOptionIds: MutableList<Int>
+)

--- a/core-model/src/main/java/com/hmoa/core_model/data/HbtiQuestionItems.kt
+++ b/core-model/src/main/java/com/hmoa/core_model/data/HbtiQuestionItems.kt
@@ -1,0 +1,7 @@
+package com.hmoa.core_model.data
+
+typealias QuestionPageIndex = Int
+
+data class HbtiQuestionItems(
+    val hbtiQuestions: MutableMap<QuestionPageIndex, HbtiQuestionItem>
+)

--- a/core-model/src/main/java/com/hmoa/core_model/response/SurveyQuestionResponseDto.kt
+++ b/core-model/src/main/java/com/hmoa/core_model/response/SurveyQuestionResponseDto.kt
@@ -6,5 +6,6 @@ import kotlinx.serialization.Serializable
 data class SurveyQuestionResponseDto(
     val answers: List<SurveyOptionResponseDto>,
     val content: String,
+    val isMultipleChoice: Boolean,
     val questionId: Int
 )

--- a/feature-hbti/src/main/java/com/hmoa/feature_hbti/screen/HbtiSurveyResultScreen.kt
+++ b/feature-hbti/src/main/java/com/hmoa/feature_hbti/screen/HbtiSurveyResultScreen.kt
@@ -241,5 +241,5 @@ private fun HbtiSurveyResultPreview() {
         )
     )
 
-    HbtiSurveyResultContent(result, {})
+    HbtiSurveyResultContent(result, {}, "테스터")
 }

--- a/feature-hbti/src/main/java/com/hmoa/feature_hbti/screen/HbtiSurveyResultScreen.kt
+++ b/feature-hbti/src/main/java/com/hmoa/feature_hbti/screen/HbtiSurveyResultScreen.kt
@@ -72,7 +72,9 @@ private fun HbtiSurveyResultScreen(
             } else {
                 HbtiSurveyResultContent(
                     surveyResult = (uiState as HbtiSurveyResultUiState.HbtiSurveyResultData).surveyResult,
-                    onHbtiProcessClick = { onHbtiProcessClick() })
+                    onHbtiProcessClick = { onHbtiProcessClick() },
+                    userName = (uiState as HbtiSurveyResultUiState.HbtiSurveyResultData).userName
+                )
             }
         }
 
@@ -109,7 +111,11 @@ private fun HbtiSurveyResultLoading(userName: String) {
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-private fun HbtiSurveyResultContent(surveyResult: List<NoteResponseDto>, onHbtiProcessClick: () -> Unit) {
+private fun HbtiSurveyResultContent(
+    surveyResult: List<NoteResponseDto>,
+    onHbtiProcessClick: () -> Unit,
+    userName: String
+) {
     val pagerState = rememberPagerState(initialPage = 0, pageCount = { surveyResult.size })
     if (surveyResult.isNotEmpty()) {
         Column(
@@ -124,7 +130,7 @@ private fun HbtiSurveyResultContent(surveyResult: List<NoteResponseDto>, onHbtiP
                 )
                 Column(modifier = Modifier.padding(start = 16.dp)) {
                     Text(
-                        "땡땡님에게 딱 맞는 향료는\n'${surveyResult[0].noteName}'입니다",
+                        "${userName}님에게 딱 맞는 향료는\n'${surveyResult[0].noteName}'입니다",
                         style = TextStyle(fontSize = 20.sp, fontWeight = FontWeight.Bold, fontFamily = pretendard),
                         modifier = Modifier.padding(top = 20.dp, bottom = 12.dp)
                     )

--- a/feature-hbti/src/main/java/com/hmoa/feature_hbti/screen/HbtiSurveyScreen.kt
+++ b/feature-hbti/src/main/java/com/hmoa/feature_hbti/screen/HbtiSurveyScreen.kt
@@ -54,6 +54,7 @@ fun HbtiSurveyScreen(
     }
 
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val hbtiQuestionItems by viewModel.hbtiQuestionItemsState.collectAsStateWithLifecycle()
     val errorUiState by viewModel.errorUiState.collectAsStateWithLifecycle()
     val scope = rememberCoroutineScope()
 
@@ -67,6 +68,7 @@ fun HbtiSurveyScreen(
         is HbtiSurveyUiState.HbtiData -> {
             HbtiSurveyContent(
                 hbtiQuestionItems = (uiState as HbtiSurveyUiState.HbtiData).hbtiQuestionItems,
+                hbtiAnswerIds = (uiState as HbtiSurveyUiState.HbtiData).hbtiAnswerIds,
                 onClickOption = { optionId, page, item, isGoToSelectedState ->
                     viewModel.modifyAnswersToOptionId(
                         optionId = optionId,
@@ -91,6 +93,7 @@ fun HbtiSurveyScreen(
 @Composable
 fun HbtiSurveyContent(
     hbtiQuestionItems: HbtiQuestionItems?,
+    hbtiAnswerIds: List<List<Int>>?,
     onClickOption: (optionId: Int, page: Int, item: HbtiQuestionItem, isGoToSelectedState: Boolean) -> Unit,
     onClickFinishSurvey: () -> Unit,
     onBackClick: () -> Unit
@@ -167,7 +170,7 @@ fun HbtiSurveyContent(
                                 )
                             )
                             SurveyOptionList(
-                                answerIds = hbtiQuestionItems?.hbtiQuestions?.get(page)?.selectedOptionIds ?: listOf(),
+                                answerIds = hbtiAnswerIds?.get(page) ?: emptyList(),
                                 surveyOptions = hbtiQuestionItems?.hbtiQuestions?.get(page)?.optionContents ?: listOf(),
                                 surveyOptionIds = hbtiQuestionItems?.hbtiQuestions?.get(page)?.optionIds ?: listOf(),
                                 onButtonClick = { optionIndex, isGoToSelectedState ->

--- a/feature-hbti/src/main/java/com/hmoa/feature_hbti/screen/HbtiSurveyScreen.kt
+++ b/feature-hbti/src/main/java/com/hmoa/feature_hbti/screen/HbtiSurveyScreen.kt
@@ -82,7 +82,8 @@ fun HbtiSurveyScreen(
                         answers = (uiState as HbtiSurveyUiState.HbtiData).answers?.optionIds
                     )
                 },
-                onClickFinishSurvey = { viewModel.postSurveyResponds() }
+                onClickFinishSurvey = { viewModel.postSurveyResponds() },
+                onBackClick = {onBackClick()}
             )
         }
     }
@@ -95,7 +96,8 @@ fun HbtiSurveyContent(
     optionsContents: List<List<String>>?,
     options: List<List<SurveyOptionResponseDto>>?,
     onClickOption: (optionId: Int, page: Int) -> Unit,
-    onClickFinishSurvey: () -> Unit
+    onClickFinishSurvey: () -> Unit,
+    onBackClick: () -> Unit
 ) {
 
     var currentProgress by remember { mutableStateOf(0f) }
@@ -133,8 +135,13 @@ fun HbtiSurveyContent(
             titleColor = Color.Black,
             navIcon = painterResource(com.hmoa.core_designsystem.R.drawable.ic_back),
             onNavClick = {
-                subtractProgress()
-                scope.launch { pagerState.animateScrollToPage(pagerState.currentPage - 1) }
+                if(pagerState.currentPage == 0){
+                    onBackClick()
+                }
+                else{
+                    subtractProgress()
+                    scope.launch { pagerState.animateScrollToPage(pagerState.currentPage - 1) }
+                }
             }
         )
         Column(
@@ -204,5 +211,5 @@ fun HbtiSurveyContent(
 fun HbtiSurveyScreenPreview() {
     HbtiSurveyContent(questions = listOf("사과는 무슨 색인가요?", "바나나는 무슨 색인가요?", "오렌지는 무슨 색인가요?"), optionsContents = listOf(
         listOf("주황", "노랑", "빨강", "파랑"), listOf("주황", "노랑", "빨강", "파랑"), listOf("주황", "노랑", "빨강", "파랑")
-    ), options = null, onClickOption = { optionId, page -> }, onClickFinishSurvey = {})
+    ), options = null, onClickOption = { optionId, page -> }, onClickFinishSurvey = {}, onBackClick = {})
 }

--- a/feature-hbti/src/main/java/com/hmoa/feature_hbti/screen/NoteOrderQuantityPickScreen.kt
+++ b/feature-hbti/src/main/java/com/hmoa/feature_hbti/screen/NoteOrderQuantityPickScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -36,14 +35,8 @@ fun NoteOrderQuantityPickContent(
     viewModel: NoteOrderQuantityPickViewmodel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val isPickCompleted by viewModel.isPickCompleted.collectAsStateWithLifecycle()
     val noteOrderQuantityChoice by viewModel.noteOrderQuantityChoice.collectAsStateWithLifecycle()
 
-    LaunchedEffect(isPickCompleted) {
-        if (isPickCompleted) {
-            onNextClick(noteOrderQuantityChoice)
-        }
-    }
 
     when (uiState) {
         is NoteOrderQuantityPickUiState.NoteOrderQuantityPickData -> {
@@ -65,10 +58,11 @@ fun NoteOrderQuantityPickContent(
                         )
                     )
                     SurveyOptionList(
-                        initValue = (uiState as NoteOrderQuantityPickUiState.NoteOrderQuantityPickData).choiceList[0],
-                        surveyOptions = (uiState as NoteOrderQuantityPickUiState.NoteOrderQuantityPickData).choiceList,
-                        onButtonClick = { optionIndex ->
-                            viewModel.saveNoteOrderQuantityChoice(optionIndex)
+                        answerIds = (uiState as NoteOrderQuantityPickUiState.NoteOrderQuantityPickData).noteQuantityChoiceAnswersId,
+                        surveyOptions = viewModel.noteOrderQuantityChoiceContents,
+                        surveyOptionIds = viewModel.noteOrderQuantityChoiceIds,
+                        onButtonClick = { optionIndex, isGoToSelectedState ->
+                            viewModel.modifyAnswerOption(optionIndex, isGoToSelectedState)
                         }
                     )
                 }
@@ -76,7 +70,7 @@ fun NoteOrderQuantityPickContent(
                     Button(
                         isEnabled = true,
                         btnText = "다음",
-                        onClick = { viewModel.changePickState(true) },
+                        onClick = { onNextClick(noteOrderQuantityChoice) },
                         buttonModifier = Modifier.fillMaxWidth(1f).height(52.dp).background(color = Color.Black),
                         textSize = 18,
                         textColor = Color.White,

--- a/feature-hbti/src/main/java/com/hmoa/feature_hbti/viewmodel/HbtiSurveyViewmodel.kt
+++ b/feature-hbti/src/main/java/com/hmoa/feature_hbti/viewmodel/HbtiSurveyViewmodel.kt
@@ -86,8 +86,22 @@ class HbtiSurveyViewmodel @Inject constructor(private val surveyRepository: Surv
     }
 
     fun initializeHbtiAnswerIdsState(surveyQuestions: SurveyQuestionsResponseDto?): List<List<Int>> {
-        val initializedHbtiAnswerIds: List<List<Int>> = List(surveyQuestions.questions.size) { emptyList() }
-        return initializedHbtiAnswerIds
+        if (surveyQuestions?.questions?.isNotEmpty() ?: false) {
+            val initializedHbtiAnswerIds: List<List<Int>> = List(surveyQuestions?.questions!!.size) { emptyList() }
+            return initializedHbtiAnswerIds
+        }
+        return emptyList()
+    }
+
+    fun updateHbtiAnswerIdState(hbtiQuestionItems: HbtiQuestionItems): List<List<Int>> {
+        val updatedHbtiAnswersId: MutableList<MutableList<Int>> =
+            MutableList(hbtiQuestionItems.hbtiQuestions.size) { mutableListOf() }
+        hbtiQuestionItems.hbtiQuestions.map {
+            val idx = it.key
+            updatedHbtiAnswersId[idx] = it.value.selectedOptionIds
+        }
+        print(updatedHbtiAnswersId)
+        return updatedHbtiAnswersId
     }
 
     suspend fun getSurveyQuestions() {
@@ -254,20 +268,12 @@ class HbtiSurveyViewmodel @Inject constructor(private val surveyRepository: Surv
             isMultipleChoice = currentHbtiQuestionItem.isMultipleChoice,
             selectedOptionIds = updatedSelectedOptionIds
         )
-
-        _hbtiQuestionItemsState.update {
-            getUpdatedHbtiQuestionItems(
-                page = page,
-                newHbtiQuestionItem = newHbtiQuestionItem
-            )
-        }
-
-    }
-
-    fun updateHbtiAnswerIds(hbtiQuestionItems: HbtiQuestionItems?) {
-        hbtiQuestionItems.hbtiQuestions.map {
-
-        }
+        val newHbtiQuestionItems = getUpdatedHbtiQuestionItems(
+            page = page,
+            newHbtiQuestionItem = newHbtiQuestionItem
+        )
+        _hbtiQuestionItemsState.update { newHbtiQuestionItems }
+        _hbtiAnsewrIdsState.update { updateHbtiAnswerIdState(newHbtiQuestionItems) }
     }
 }
 

--- a/feature-hbti/src/main/java/com/hmoa/feature_hbti/viewmodel/HbtiSurveyViewmodel.kt
+++ b/feature-hbti/src/main/java/com/hmoa/feature_hbti/viewmodel/HbtiSurveyViewmodel.kt
@@ -25,7 +25,8 @@ typealias QuestionOptionId = Int
 class HbtiSurveyViewmodel @Inject constructor(private val surveyRepository: SurveyRepository) : ViewModel() {
     private var _hbtiQuestionItemsState = MutableStateFlow<HbtiQuestionItems?>(null)
     val hbtiQuestionItemsState: StateFlow<HbtiQuestionItems?> = _hbtiQuestionItemsState
-    private var _hbtiAnsewrIdsState = MutableStateFlow<List<List<Int>>?>(null)
+    private var _hbtiAnwserIdsState = MutableStateFlow<List<List<Int>>?>(null)
+    val hbtiAnswerIdsState: StateFlow<List<List<Int>>?> = _hbtiAnwserIdsState
     private var _finalQuestionAnswersState = MutableStateFlow<MutableList<QuestionOptionId>?>(null)
     private var expiredTokenErrorState = MutableStateFlow<Boolean>(false)
     private var wrongTypeTokenErrorState = MutableStateFlow<Boolean>(false)
@@ -52,7 +53,7 @@ class HbtiSurveyViewmodel @Inject constructor(private val surveyRepository: Surv
     val uiState: StateFlow<HbtiSurveyUiState> =
         combine(
             _hbtiQuestionItemsState,
-            _hbtiAnsewrIdsState,
+            _hbtiAnwserIdsState,
             _finalQuestionAnswersState
         ) { hbtiQuestionItemsState, hbtiAnsewrIdsState, finalQuestionAnswersState ->
             HbtiSurveyUiState.HbtiData(
@@ -115,7 +116,7 @@ class HbtiSurveyViewmodel @Inject constructor(private val surveyRepository: Surv
                             )
                         )
                     }
-                    _hbtiAnsewrIdsState.update { initializeHbtiAnswerIdsState(result.data.data) }
+                    _hbtiAnwserIdsState.update { initializeHbtiAnswerIdsState(result.data.data) }
                 }
 
                 is Result.Error -> {
@@ -273,7 +274,7 @@ class HbtiSurveyViewmodel @Inject constructor(private val surveyRepository: Surv
             newHbtiQuestionItem = newHbtiQuestionItem
         )
         _hbtiQuestionItemsState.update { newHbtiQuestionItems }
-        _hbtiAnsewrIdsState.update { updateHbtiAnswerIdState(newHbtiQuestionItems) }
+        _hbtiAnwserIdsState.update { updateHbtiAnswerIdState(newHbtiQuestionItems) }
     }
 }
 

--- a/feature-hbti/src/test/java/com/hmoa/feature_hbti/HbitSurveyViewModelTest.kt
+++ b/feature-hbti/src/test/java/com/hmoa/feature_hbti/HbitSurveyViewModelTest.kt
@@ -77,7 +77,6 @@ class HbitSurveyViewModelTest : TestCase() {
         runBlocking {
             Mockito.`when`(surveyRepository.getSurveyQuestions()).thenReturn(fakeResponse)
             viewModel = spy(HbtiSurveyViewmodel(surveyRepository)) //내부 메서드 호출 감지 가능
-            println("setUp")
         }
     }
 
@@ -258,6 +257,32 @@ class HbitSurveyViewModelTest : TestCase() {
             isGoToSelectedState = true
         )
         assertEquals(expectedValue, viewModel.hbtiQuestionItemsState.value)
+    }
 
+    @Test
+    fun `test_hbtiAnswerIds 배열 초기화`() = coroutineRule.runTest {
+        val expectedValue: List<List<Int>> = List(2) { emptyList() }
+        val result = viewModel.initializeHbtiAnswerIdsState(fakeResponse.data)
+        assertEquals(expectedValue, result)
+    }
+
+    @Test
+    fun `test_hbtiQuestionsItems 맵의 키값 selectedOptionIds로부터 hbtiAnswerIds 배열이 갱신된 값 확인`() = coroutineRule.runTest {
+        val expectedValue: List<List<Int>> =
+            listOf(listOf(hbtiQuestionItem_singleChoice.optionIds[0]), listOf())
+        viewModel.getSurveyQuestions()
+        launch {
+            viewModel.modifyAnswersToOptionId(
+                0,
+                hbtiQuestionItem_singleChoice.optionIds[0],
+                hbtiQuestionItem_singleChoice,
+                true
+            )
+        }.join()
+
+        val result = viewModel.updateHbtiAnswerIdState(
+            HbtiQuestionItems(viewModel.hbtiQuestionItemsState.value!!.hbtiQuestions)
+        )
+        assertEquals(expectedValue, result)
     }
 }

--- a/feature-hbti/src/test/java/com/hmoa/feature_hbti/HbitSurveyViewModelTest.kt
+++ b/feature-hbti/src/test/java/com/hmoa/feature_hbti/HbitSurveyViewModelTest.kt
@@ -279,10 +279,7 @@ class HbitSurveyViewModelTest : TestCase() {
                 true
             )
         }.join()
-
-        val result = viewModel.updateHbtiAnswerIdState(
-            HbtiQuestionItems(viewModel.hbtiQuestionItemsState.value!!.hbtiQuestions)
-        )
-        assertEquals(expectedValue, result)
+        
+        assertEquals(expectedValue, viewModel.hbtiAnswerIdsState.value)
     }
 }

--- a/feature-hbti/src/test/java/com/hmoa/feature_hbti/HbitSurveyViewModelTest.kt
+++ b/feature-hbti/src/test/java/com/hmoa/feature_hbti/HbitSurveyViewModelTest.kt
@@ -2,18 +2,20 @@ package com.hmoa.feature_hbti
 
 import ResultResponse
 import com.hmoa.core_domain.repository.SurveyRepository
+import com.hmoa.core_model.data.HbtiQuestionItem
+import com.hmoa.core_model.data.HbtiQuestionItems
 import com.hmoa.core_model.response.SurveyOptionResponseDto
 import com.hmoa.core_model.response.SurveyQuestionResponseDto
 import com.hmoa.core_model.response.SurveyQuestionsResponseDto
 import com.hmoa.feature_hbti.viewmodel.HbtiSurveyViewmodel
 import junit.framework.TestCase
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito
-import org.mockito.Mockito.mock
+import org.mockito.Mockito.*
 
 class HbitSurveyViewModelTest : TestCase() {
     @get:Rule(order = 0)
@@ -21,83 +23,241 @@ class HbitSurveyViewModelTest : TestCase() {
 
     private val surveyRepository = mock(SurveyRepository::class.java)
     lateinit var viewModel: HbtiSurveyViewmodel
+    lateinit var hbtiQuestionItem_singleChoice: HbtiQuestionItem
+    lateinit var hbtiQuestionItem_multiChoice: HbtiQuestionItem
 
-    val fakeQuestions = listOf(
-        SurveyQuestionResponseDto(
+    companion object {
+        //0번째 질문, page = 0
+        val fakeQuestion1 = SurveyQuestionResponseDto(
             answers = listOf(
                 SurveyOptionResponseDto(option = "봄", optionId = 0),
                 SurveyOptionResponseDto(option = "여름", optionId = 1),
                 SurveyOptionResponseDto(option = "가을", optionId = 2),
                 SurveyOptionResponseDto(option = "겨울", optionId = 3)
-            ), content = "좋아하는 계절이 무엇입니까?", questionId = 0
-        ),
-        SurveyQuestionResponseDto(
+            ), content = "좋아하는 계절이 무엇입니까?", questionId = 0, isMultipleChoice = false
+        )
+
+        //1번째 질문, page = 1
+        val fakeQuestion2 = SurveyQuestionResponseDto(
             answers = listOf(
                 SurveyOptionResponseDto(option = "도시", optionId = 0),
                 SurveyOptionResponseDto(option = "숲", optionId = 1),
                 SurveyOptionResponseDto(option = "바다", optionId = 2),
                 SurveyOptionResponseDto(option = "호수", optionId = 3)
-            ), content = "좋아하는 여행지는 무엇입니까?", questionId = 0
+            ), content = "좋아하는 여행지는 무엇입니까?", questionId = 1, isMultipleChoice = true
         )
-    )
-    val fakeResponse = ResultResponse<SurveyQuestionsResponseDto>(
-        SurveyQuestionsResponseDto(
-            questions = fakeQuestions,
-            title = "hbti테스트 질문"
+        val fakeQuestions = listOf(fakeQuestion1, fakeQuestion2)
+        val fakeResponse = ResultResponse<SurveyQuestionsResponseDto>(
+            SurveyQuestionsResponseDto(
+                questions = fakeQuestions,
+                title = "hbti테스트 질문"
+            )
         )
-    )
+    }
+
 
     @Before
     override fun setUp() {
+        hbtiQuestionItem_singleChoice = HbtiQuestionItem(
+            questionId = fakeQuestion1.questionId,
+            questionContent = fakeQuestion1.content,
+            optionIds = fakeQuestion1.answers.map { it.optionId },
+            optionContents = fakeQuestion1.answers.map { it.option },
+            isMultipleChoice = fakeQuestion1.isMultipleChoice,
+            selectedOptionIds = mutableListOf()
+        )
+        hbtiQuestionItem_multiChoice = HbtiQuestionItem(
+            questionId = fakeQuestion2.questionId,
+            questionContent = fakeQuestion2.content,
+            optionIds = fakeQuestion2.answers.map { it.optionId },
+            optionContents = fakeQuestion2.answers.map { it.option },
+            isMultipleChoice = fakeQuestion2.isMultipleChoice,
+            selectedOptionIds = mutableListOf()
+        )
         runBlocking {
             Mockito.`when`(surveyRepository.getSurveyQuestions()).thenReturn(fakeResponse)
-            viewModel = HbtiSurveyViewmodel(surveyRepository)
+            viewModel = spy(HbtiSurveyViewmodel(surveyRepository)) //내부 메서드 호출 감지 가능
+            println("setUp")
         }
     }
 
     @Test
-    fun testInitializeAnswer() = coroutineRule.runTest {
-        Assert.assertEquals(mutableListOf(0, 0), viewModel.initializeAnswerState(fakeResponse.data))
-    }
-
-    @Test
-    fun testUpdateQuestion() = coroutineRule.runTest {
-        Assert.assertEquals(
-            listOf("좋아하는 계절이 무엇입니까?", "좋아하는 여행지는 무엇입니까?"),
-            viewModel.updateQuestionState(fakeResponse.data)
+    fun `test_getSurveyQuestions 요청 성공 후 hbtiQuestionItems의 초기화된 상태값 확인`() = coroutineRule.runTest {
+        val expectedValue = HbtiQuestionItems(
+            hbtiQuestions = mutableMapOf(
+                0 to hbtiQuestionItem_singleChoice,
+                1 to hbtiQuestionItem_multiChoice
+            )
         )
+        launch { viewModel.getSurveyQuestions() }.join()
+        assertEquals(expectedValue, viewModel.hbtiQuestionItemsState.value)
     }
 
     @Test
-    fun testUpdateOptionContent() = coroutineRule.runTest {
-        Assert.assertEquals(
-            listOf(listOf("봄", "여름", "가을", "겨울"), listOf("도시", "숲", "바다", "호수")),
-            viewModel.updateOptionContentState(fakeResponse.data)
+    fun `test_getSurveyQuestions 요청 성공 후 hbtiQuestionItems 초기화 함수 호출 여부 확인`() = coroutineRule.runTest {
+        launch { viewModel.getSurveyQuestions() }.join()
+        verify(viewModel).initializeHbtiQuestionItemsState(fakeResponse.data)
+    }
+
+    @Test
+    fun `test_단일 선택인 질문 답안을 처음 선택한 경우, 정답으로 업데이트 되었는지 확인`() = coroutineRule.runTest {
+        val expectedValue = mutableListOf(hbtiQuestionItem_singleChoice.optionIds[0])
+        val result = viewModel.increaseHbtiQuestionItem_SelectedOption(
+            hbtiQuestionItem_singleChoice.optionIds[0],
+            hbtiQuestionItem_singleChoice.isMultipleChoice,
+            hbtiQuestionItem_singleChoice.selectedOptionIds
         )
+        assertEquals(expectedValue, result)
     }
 
     @Test
-    fun testUpdateOptions() = coroutineRule.runTest {
-        Assert.assertEquals(
-            listOf(
-                listOf(
-                    SurveyOptionResponseDto(option = "봄", optionId = 0),
-                    SurveyOptionResponseDto(option = "여름", optionId = 1),
-                    SurveyOptionResponseDto(option = "가을", optionId = 2),
-                    SurveyOptionResponseDto(option = "겨울", optionId = 3)
-                ), listOf(
-                    SurveyOptionResponseDto(option = "도시", optionId = 0),
-                    SurveyOptionResponseDto(option = "숲", optionId = 1),
-                    SurveyOptionResponseDto(option = "바다", optionId = 2),
-                    SurveyOptionResponseDto(option = "호수", optionId = 3)
+    fun `test_단일 선택인 질문의 정답을 바꾸는 경우, 기존 정답이 없어지고 새로운 정답으로 업데이트 되는지 확인`() = coroutineRule.runTest {
+        val expectedOldValue = mutableListOf(hbtiQuestionItem_singleChoice.optionIds[0])
+        val expectedNewValue = mutableListOf(hbtiQuestionItem_singleChoice.optionIds[1])
+        //기존 정답 입력
+        val oldResult = viewModel.increaseHbtiQuestionItem_SelectedOption(
+            hbtiQuestionItem_singleChoice.optionIds[0],
+            hbtiQuestionItem_singleChoice.isMultipleChoice,
+            hbtiQuestionItem_singleChoice.selectedOptionIds
+        )
+        assertEquals(expectedOldValue, oldResult)
+        //새로운 정답 입력
+        val newResult = viewModel.increaseHbtiQuestionItem_SelectedOption(
+            hbtiQuestionItem_singleChoice.optionIds[1],
+            hbtiQuestionItem_singleChoice.isMultipleChoice,
+            hbtiQuestionItem_singleChoice.selectedOptionIds
+        )
+        assertEquals(expectedNewValue, newResult)
+    }
+
+    @Test
+    fun `test_복수 선택인 질문 답안을 처음 선택한 경우, 정답으로 업데이트 되었는지 확인`() = coroutineRule.runTest {
+        val expectedValue =
+            mutableListOf(hbtiQuestionItem_multiChoice.optionIds[0], hbtiQuestionItem_multiChoice.optionIds[1])
+        viewModel.increaseHbtiQuestionItem_SelectedOption(
+            hbtiQuestionItem_multiChoice.optionIds[0],
+            hbtiQuestionItem_multiChoice.isMultipleChoice,
+            hbtiQuestionItem_multiChoice.selectedOptionIds
+        )
+        val result = viewModel.increaseHbtiQuestionItem_SelectedOption(
+            hbtiQuestionItem_multiChoice.optionIds[1],
+            hbtiQuestionItem_multiChoice.isMultipleChoice,
+            hbtiQuestionItem_multiChoice.selectedOptionIds
+        )
+        assertEquals(expectedValue, result)
+    }
+
+    @Test
+    fun `test_복수 선택인 질문의 정답을 추가하는 경우, 기존 정답 뒤에 새로운 정답이 추가되는지 확인`() = coroutineRule.runTest {
+        val expectedValue =
+            mutableListOf(hbtiQuestionItem_multiChoice.optionIds[0], hbtiQuestionItem_multiChoice.optionIds[1])
+        viewModel.increaseHbtiQuestionItem_SelectedOption(
+            hbtiQuestionItem_multiChoice.optionIds[0],
+            hbtiQuestionItem_multiChoice.isMultipleChoice,
+            hbtiQuestionItem_multiChoice.selectedOptionIds
+        )
+        val result = viewModel.increaseHbtiQuestionItem_SelectedOption(
+            hbtiQuestionItem_multiChoice.optionIds[1],
+            hbtiQuestionItem_multiChoice.isMultipleChoice,
+            hbtiQuestionItem_multiChoice.selectedOptionIds
+        )
+        assertEquals(expectedValue, result)
+    }
+
+    @Test
+    fun `test_단수 선택인 질문의 정답을 삭제하는 경우, 정답 리스트가 비어있는지 확인`() = coroutineRule.runTest {
+        viewModel.increaseHbtiQuestionItem_SelectedOption(
+            hbtiQuestionItem_multiChoice.optionIds[0],
+            hbtiQuestionItem_multiChoice.isMultipleChoice,
+            hbtiQuestionItem_multiChoice.selectedOptionIds
+        )
+        val result = viewModel.decreaseHbtiQuestionItem_SelectedOption(
+            hbtiQuestionItem_multiChoice.optionIds[0],
+            hbtiQuestionItem_multiChoice.selectedOptionIds
+        )
+        assert(result.isEmpty())
+    }
+
+    @Test
+    fun `test_복수 선택인 질문의 정답을 변경하는 경우,정답 2개 중 두번째를 삭제하고 새로운 정답을 추가했을 때 결과 확인`() = coroutineRule.runTest {
+        val expectedValue =
+            mutableListOf(hbtiQuestionItem_multiChoice.optionIds[0], hbtiQuestionItem_multiChoice.optionIds[2])
+        viewModel.increaseHbtiQuestionItem_SelectedOption(
+            hbtiQuestionItem_multiChoice.optionIds[0],
+            hbtiQuestionItem_multiChoice.isMultipleChoice,
+            hbtiQuestionItem_multiChoice.selectedOptionIds
+        )
+        viewModel.increaseHbtiQuestionItem_SelectedOption(
+            hbtiQuestionItem_multiChoice.optionIds[1],
+            hbtiQuestionItem_multiChoice.isMultipleChoice,
+            hbtiQuestionItem_multiChoice.selectedOptionIds
+        )
+        viewModel.decreaseHbtiQuestionItem_SelectedOption(
+            hbtiQuestionItem_multiChoice.optionIds[1],
+            hbtiQuestionItem_multiChoice.selectedOptionIds
+        )
+        val result = viewModel.increaseHbtiQuestionItem_SelectedOption(
+            hbtiQuestionItem_multiChoice.optionIds[2],
+            hbtiQuestionItem_multiChoice.isMultipleChoice,
+            hbtiQuestionItem_multiChoice.selectedOptionIds
+        )
+        assertEquals(expectedValue, result)
+    }
+
+    @Test
+    fun `test_getUpdatedHbtiQuestionItems, 수정된 답안이 HbtiQuestionItems의 page인덱스에 정확히 삽입되는지 확인 `() =
+        coroutineRule.runTest {
+            val updatedItem = HbtiQuestionItem(
+                questionId = hbtiQuestionItem_multiChoice.questionId,
+                questionContent = hbtiQuestionItem_multiChoice.questionContent,
+                optionIds = hbtiQuestionItem_multiChoice.optionIds,
+                optionContents = hbtiQuestionItem_multiChoice.optionContents,
+                isMultipleChoice = hbtiQuestionItem_multiChoice.isMultipleChoice,
+                selectedOptionIds = mutableListOf(
+                    hbtiQuestionItem_multiChoice.optionIds[0],
+                    hbtiQuestionItem_multiChoice.optionIds[1]
                 )
-            ), viewModel.updateOptionsState(fakeResponse.data)
-        )
-    }
+            )
+            val expectedValue =
+                HbtiQuestionItems(hbtiQuestions = mutableMapOf(0 to hbtiQuestionItem_singleChoice, 1 to updatedItem))
+
+            viewModel.getSurveyQuestions()
+            val result = viewModel.getUpdatedHbtiQuestionItems(page = 1, newHbtiQuestionItem = updatedItem)
+            assertEquals(expectedValue, result)
+        }
 
     @Test
-    fun testAnswerFrom0To1() = coroutineRule.runTest {
-        val answers = mutableListOf(0, 0)
-        Assert.assertEquals(mutableListOf(1, 0), viewModel.modifyAnswers(0, 1, answers))
+    fun `test_복수 선택인 질문 1개에 대해 정답을 2개를 선택했을 경우, hbtiQuestioinItemsState가 이를 반영했는지 상태값 확인`() = coroutineRule.runTest {
+        val expectedValue = HbtiQuestionItems(
+            hbtiQuestions = mutableMapOf(
+                0 to hbtiQuestionItem_singleChoice,
+                1 to HbtiQuestionItem(
+                    questionId = hbtiQuestionItem_multiChoice.questionId,
+                    questionContent = hbtiQuestionItem_multiChoice.questionContent,
+                    optionIds = hbtiQuestionItem_multiChoice.optionIds,
+                    optionContents = hbtiQuestionItem_multiChoice.optionContents,
+                    isMultipleChoice = hbtiQuestionItem_multiChoice.isMultipleChoice,
+                    selectedOptionIds = mutableListOf(
+                        hbtiQuestionItem_multiChoice.optionIds[0],
+                        hbtiQuestionItem_multiChoice.optionIds[1]
+                    )
+                )
+            )
+        )
+        viewModel.getSurveyQuestions()
+        viewModel.modifyAnswersToOptionId(
+            page = 1,
+            optionId = hbtiQuestionItem_multiChoice.optionIds[0],
+            currentHbtiQuestionItem = hbtiQuestionItem_multiChoice,
+            isGoToSelectedState = true
+        )
+        viewModel.modifyAnswersToOptionId(
+            page = 1,
+            optionId = hbtiQuestionItem_multiChoice.optionIds[1],
+            currentHbtiQuestionItem = hbtiQuestionItem_multiChoice,
+            isGoToSelectedState = true
+        )
+        assertEquals(expectedValue, viewModel.hbtiQuestionItemsState.value)
+
     }
 }

--- a/feature-hbti/src/test/java/com/hmoa/feature_hbti/HbitSurveyViewModelTest.kt
+++ b/feature-hbti/src/test/java/com/hmoa/feature_hbti/HbitSurveyViewModelTest.kt
@@ -279,7 +279,27 @@ class HbitSurveyViewModelTest : TestCase() {
                 true
             )
         }.join()
-        
+
         assertEquals(expectedValue, viewModel.hbtiAnswerIdsState.value)
+    }
+
+    @Test
+    fun `test_설문 종료 후 선택한 정답들의 Id값이 리스트에 담기는지 확인`() = coroutineRule.runTest {
+        val expectedValue = listOf(0, 0)
+        viewModel.getSurveyQuestions()
+        viewModel.modifyAnswersToOptionId(
+            0,
+            hbtiQuestionItem_singleChoice.optionIds[0],
+            hbtiQuestionItem_singleChoice,
+            true
+        )
+        viewModel.modifyAnswersToOptionId(
+            1,
+            hbtiQuestionItem_multiChoice.optionIds[0],
+            hbtiQuestionItem_multiChoice,
+            true
+        )
+        val result = viewModel.arrangeAllAnswersIdToFinalQuestionAnswerState()
+        assertEquals(expectedValue, result)
     }
 }

--- a/feature-hbti/src/test/java/com/hmoa/feature_hbti/HbtiSurveyViewModelTest.kt
+++ b/feature-hbti/src/test/java/com/hmoa/feature_hbti/HbtiSurveyViewModelTest.kt
@@ -17,7 +17,7 @@ import org.junit.Test
 import org.mockito.Mockito
 import org.mockito.Mockito.*
 
-class HbitSurveyViewModelTest : TestCase() {
+class HbtiSurveyViewModelTest : TestCase() {
     @get:Rule(order = 0)
     val coroutineRule = TestCoroutineRule()
 

--- a/feature-hbti/src/test/java/com/hmoa/feature_hbti/NoteOrderQuantityPickViewmodelTest.kt
+++ b/feature-hbti/src/test/java/com/hmoa/feature_hbti/NoteOrderQuantityPickViewmodelTest.kt
@@ -1,0 +1,69 @@
+package com.hmoa.feature_hbti
+
+import com.hmoa.core_domain.repository.SurveyRepository
+import com.hmoa.core_model.request.NoteResponseDto
+import com.hmoa.feature_hbti.viewmodel.NoteOrderQuantityPickViewmodel
+import junit.framework.TestCase
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.spy
+
+class NoteOrderQuantityPickViewmodelTest : TestCase() {
+    @get:Rule(order = 0)
+    val coroutineRule = TestCoroutineRule()
+    private val surveyRepository = mock(SurveyRepository::class.java)
+    lateinit var viewmodel: NoteOrderQuantityPickViewmodel
+
+    companion object {
+        val fakeSurveyResult = listOf(
+            NoteResponseDto(
+                content = "상큼한 과일향기",
+                noteId = 4,
+                noteName = "시트러스",
+                notePhotoUrl = "fake_notePhotoUrl"
+            )
+        )
+    }
+
+    @Before
+    override fun setUp() {
+        runBlocking {
+            Mockito.`when`(surveyRepository.getAllSurveyResult()).thenReturn(fakeSurveyResult)
+        }
+        viewmodel = spy(NoteOrderQuantityPickViewmodel(surveyRepository))
+    }
+
+    @Test
+    fun `test_주문수량 선택지 업데이트 메소드_빈 배열에 새로운 값 추가_추가된 값 확인`() = coroutineRule.runTest {
+        val expectedValue = listOf(0)
+        val result = viewmodel.updateAnswerOption(emptyList(), 0)
+        assertEquals(expectedValue, result)
+    }
+
+    @Test
+    fun `test_주문수량 선택지 업데이트 메소드_기존 값을 새로운 값으로 교체_교체된 값 확인`() = coroutineRule.runTest {
+        val expectedValue = listOf(1)
+        val answerIds = emptyList<Int>()
+        viewmodel.updateAnswerOption(answerIds, 0)
+        val result = viewmodel.updateAnswerOption(answerIds, 1)
+        assertEquals(expectedValue, result)
+    }
+
+    @Test
+    fun `test_주문수량 선택_빈 배열에 새로운 값 추가_상태변수 값 확인`() = coroutineRule.runTest {
+        val expectedValue = listOf(0)
+        viewmodel.modifyAnswerOption(0, true)
+        assertEquals(expectedValue, viewmodel.noteQuantityChoiceAnswersId.value)
+    }
+
+    @Test
+    fun `test_주문수량 선택지 취소_정답배열이 빈 배열인지 확인`() = coroutineRule.runTest {
+        val expectedValue = emptyList<Int>()
+        viewmodel.modifyAnswerOption(0, false)
+        assertEquals(expectedValue, viewmodel.noteQuantityChoiceAnswersId.value)
+    }
+}

--- a/feature-userInfo/src/main/java/com/hmoa/feature_userinfo/Screen/MyPage.kt
+++ b/feature-userInfo/src/main/java/com/hmoa/feature_userinfo/Screen/MyPage.kt
@@ -200,7 +200,7 @@ private fun MyPageContent(
                 provider = provider,
                 onNavEditProfile = onNavEditProfile
             )
-            ServiceAlarm()
+            //ServiceAlarm()
             HorizontalDivider(thickness = 1.dp, color = CustomColor.gray2)
         }
 


### PR DESCRIPTION
@uselessnaming 
# 기능 수정
## note/survey 오류
저도 오류 현상을 겪긴 했는데 아래의 설문 제출, 주문수량 선택 기능을 수정하면서 더 이상 발생을 안하게 되었습니다🤔
생각해보니까 feature/hbti관련 브랜치는 패키지 수정이랑 관련이 없는 거 같기도 하구요🤔
혹시 이 PR을 병합한 이후에도 또 발생하면 멘션 부탁드립니다!🙏

## SurveyOptionList 컴포넌트 수정
선택지를 고르고 다음화면에 넘어가면 이전화면의 선택지 상태유지가 안되는 불편함이 있었는데 결국 컴포넌트를 뜯어고쳐서 수정했습니다..!😀
1차 명세 부분의 선택지 컴포넌트가 들어가는 화면 2개는 제가 작업했지만
아마 2차 명세 UI만 미리 구현해놓은 부분에서 오류가 뜰 거 같아요🥺 수정된 SurveyOptionList에 맞춰서 다시 리팩토링 되어야 할 거 같습니다. HbtiSurveyViewmodel, NoteOrderQuantityPickViewmodel 부분은 이참에 테스트 커버리지를 50%, 71%까지 높여보았는데
단점은 테스트작성까지 하면 시간이...2배 정도로 더 걸린 거 같습니다ㅠ장점은 에뮬레이터를 켜기 전에 오류를 거의 다 잡을 수 있다는 점인듯요
