### PR TITLE
Release CI 작업 트리거 수정

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,11 +1,6 @@
 name: Android develop CI
 
 on:
-  push:
-    branches:
-      - "feature/hbti"
-      - "release"
-      - "master"
   pull_request:
     branches:
       - "feature/hbti"


### PR DESCRIPTION
@uselessnaming 
PR이랑 코드푸시 둘 다 트리거로 설정되어있었는데 굳이 2번 할 필요가 없어서
코드푸시 조건은 삭제했습니다