### PR TITLE
Feature/hbti lyi 에러핸들링 함수 추가

### DIFF
--- a/core-common/build.gradle.kts
+++ b/core-common/build.gradle.kts
@@ -30,6 +30,7 @@ android {
 }
 
 dependencies {
+    implementation(project(":core-model"))
 
     implementation("androidx.core:core-ktx:1.9.0")
     implementation("androidx.appcompat:appcompat:1.6.1")

--- a/core-common/src/main/java/com/hmoa/core_common/ErrorHandleFunctions.kt
+++ b/core-common/src/main/java/com/hmoa/core_common/ErrorHandleFunctions.kt
@@ -1,0 +1,29 @@
+package com.hmoa.core_common
+
+import ResultResponse
+
+suspend fun <T> ResultResponse<T>.emitOrThrow(emit: suspend (ResultResponse<T>) -> Unit) {
+    if (this.data != null) {
+        emit(this)
+    } else if (this.errorMessage != null) {
+        throw Exception(this.errorMessage!!.message)
+    }
+}
+
+fun handleErrorType(
+    error: Throwable,
+    onExpiredTokenError: () -> Unit,
+    onWrongTypeTokenError: () -> Unit,
+    onUnknownError: () -> Unit,
+    onGeneralError: () -> Unit
+) {
+    when (error.message) {
+        ErrorMessageType.EXPIRED_TOKEN.message -> onExpiredTokenError()
+
+        ErrorMessageType.WRONG_TYPE_TOKEN.message -> onWrongTypeTokenError()
+
+        ErrorMessageType.UNKNOWN_ERROR.message -> onUnknownError()
+
+        else -> onGeneralError()
+    }
+}

--- a/feature-hbti/src/main/java/com/hmoa/feature_hbti/viewmodel/HbtiSurveyViewmodel.kt
+++ b/feature-hbti/src/main/java/com/hmoa/feature_hbti/viewmodel/HbtiSurveyViewmodel.kt
@@ -2,10 +2,7 @@ package com.hmoa.feature_hbti.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.hmoa.core_common.ErrorMessageType
-import com.hmoa.core_common.ErrorUiState
-import com.hmoa.core_common.Result
-import com.hmoa.core_common.asResult
+import com.hmoa.core_common.*
 import com.hmoa.core_domain.repository.SurveyRepository
 import com.hmoa.core_model.data.HbtiQuestionItem
 import com.hmoa.core_model.data.HbtiQuestionItems
@@ -22,20 +19,23 @@ import javax.inject.Inject
 typealias QuestionPageIndex = Int
 
 @HiltViewModel
-class HbtiSurveyViewmodel @Inject constructor(private val surveyRepository: SurveyRepository) : ViewModel() {
+class HbtiSurveyViewmodel @Inject constructor(
+    private val surveyRepository: SurveyRepository,
+) : ViewModel() {
     private var _hbtiQuestionItemsState = MutableStateFlow<HbtiQuestionItems?>(null)
     val hbtiQuestionItemsState: StateFlow<HbtiQuestionItems?> = _hbtiQuestionItemsState
     private var _hbtiAnwserIdsState = MutableStateFlow<List<List<Int>>?>(null)
     val hbtiAnswerIdsState: StateFlow<List<List<Int>>?> = _hbtiAnwserIdsState
-    private var expiredTokenErrorState = MutableStateFlow<Boolean>(false)
-    private var wrongTypeTokenErrorState = MutableStateFlow<Boolean>(false)
-    private var unLoginedErrorState = MutableStateFlow<Boolean>(false)
-    private var generalErrorState = MutableStateFlow<Pair<Boolean, String?>>(Pair(false, null))
+    private var _expiredTokenErrorState = MutableStateFlow<Boolean>(false)
+    private var _wrongTypeTokenErrorState = MutableStateFlow<Boolean>(false)
+    private var _unLoginedErrorState = MutableStateFlow<Boolean>(false)
+    val unLoginedErrorState: StateFlow<Boolean> = _unLoginedErrorState
+    private var _generalErrorState = MutableStateFlow<Pair<Boolean, String?>>(Pair(false, null))
     val errorUiState: StateFlow<ErrorUiState> = combine(
-        expiredTokenErrorState,
-        wrongTypeTokenErrorState,
-        unLoginedErrorState,
-        generalErrorState
+        _expiredTokenErrorState,
+        _wrongTypeTokenErrorState,
+        _unLoginedErrorState,
+        _generalErrorState
     ) { expiredTokenError, wrongTypeTokenError, unknownError, generalError ->
         ErrorUiState.ErrorData(
             expiredTokenError = expiredTokenError,
@@ -104,48 +104,37 @@ class HbtiSurveyViewmodel @Inject constructor(private val surveyRepository: Surv
     suspend fun getSurveyQuestions() {
         flow {
             val result = surveyRepository.getSurveyQuestions()
+            result.emitOrThrow { emit(it) }
+        }
+            .asResult()
+            .collectLatest { result ->
+                when (result) {
+                    Result.Loading -> {
+                        HbtiSurveyUiState.Loading
+                    }
 
-            if (result.data != null) {
-                emit(result)
-            } else if (result.errorMessage != null) {
-                throw Exception(result.errorMessage!!.message)
-            }
-        }.asResult().collectLatest { result ->
-            when (result) {
-                is Result.Success -> {
-                    _hbtiQuestionItemsState.update {
-                        HbtiQuestionItems(
-                            hbtiQuestions = initializeHbtiQuestionItemsState(
-                                result.data.data
+                    is Result.Success -> {
+                        _hbtiQuestionItemsState.update {
+                            HbtiQuestionItems(
+                                hbtiQuestions = initializeHbtiQuestionItemsState(
+                                    result.data.data
+                                )
                             )
+                        }
+                        _hbtiAnwserIdsState.update { initializeHbtiAnswerIdsState(result.data.data) }
+                    }
+
+                    is Result.Error -> {
+                        handleErrorType(
+                            error = result.exception,
+                            onExpiredTokenError = { _expiredTokenErrorState.update { true } },
+                            onWrongTypeTokenError = { _wrongTypeTokenErrorState.update { true } },
+                            onUnknownError = { _unLoginedErrorState.update { true } },
+                            onGeneralError = { _generalErrorState.update { Pair(true, result.exception.message) } }
                         )
                     }
-                    _hbtiAnwserIdsState.update { initializeHbtiAnswerIdsState(result.data.data) }
                 }
-
-                is Result.Error -> {
-                    when (result.exception.message) {
-                        ErrorMessageType.EXPIRED_TOKEN.message -> {
-                            expiredTokenErrorState.update { true }
-                        }
-
-                        ErrorMessageType.WRONG_TYPE_TOKEN.message -> {
-                            wrongTypeTokenErrorState.update { true }
-                        }
-
-                        ErrorMessageType.UNKNOWN_ERROR.message -> {
-                            unLoginedErrorState.update { true }
-                        }
-
-                        else -> {
-                            generalErrorState.update { Pair(true, result.exception.message) }
-                        }
-                    }
-                }
-
-                Result.Loading -> HbtiSurveyUiState.Loading
             }
-        }
     }
 
     suspend fun saveSurveyResultToLocalDB(result: List<NoteResponseDto>?) {
@@ -183,19 +172,19 @@ class HbtiSurveyViewmodel @Inject constructor(private val surveyRepository: Surv
                     is Result.Error -> {
                         when (result.exception.message) {
                             ErrorMessageType.EXPIRED_TOKEN.message -> {
-                                expiredTokenErrorState.update { true }
+                                _expiredTokenErrorState.update { true }
                             }
 
                             ErrorMessageType.WRONG_TYPE_TOKEN.message -> {
-                                wrongTypeTokenErrorState.update { true }
+                                _wrongTypeTokenErrorState.update { true }
                             }
 
                             ErrorMessageType.UNKNOWN_ERROR.message -> {
-                                unLoginedErrorState.update { true }
+                                _unLoginedErrorState.update { true }
                             }
 
                             else -> {
-                                generalErrorState.update { Pair(true, result.exception.message) }
+                                _generalErrorState.update { Pair(true, result.exception.message) }
                             }
                         }
                     }

--- a/feature-hbti/src/test/java/com/hmoa/feature_hbti/HbtiSurveyViewModelTest.kt
+++ b/feature-hbti/src/test/java/com/hmoa/feature_hbti/HbtiSurveyViewModelTest.kt
@@ -1,7 +1,9 @@
 package com.hmoa.feature_hbti
 
 import ResultResponse
+import com.hmoa.core_common.ErrorMessageType
 import com.hmoa.core_domain.repository.SurveyRepository
+import com.hmoa.core_model.data.ErrorMessage
 import com.hmoa.core_model.data.HbtiQuestionItem
 import com.hmoa.core_model.data.HbtiQuestionItems
 import com.hmoa.core_model.response.SurveyOptionResponseDto
@@ -91,6 +93,22 @@ class HbtiSurveyViewModelTest : TestCase() {
         )
         launch { viewModel.getSurveyQuestions() }.join()
         assertEquals(expectedValue, viewModel.hbtiQuestionItemsState.value)
+    }
+
+    @Test
+    fun `test_getSurveyQuestions Unkown error요청실패_unLoginedErrorState값 확인`() = coroutineRule.runTest {
+        val expectedUnLoginedErrorState = true
+        Mockito.`when`(surveyRepository.getSurveyQuestions()).thenReturn(
+            ResultResponse(
+                data = null,
+                errorMessage = ErrorMessage(
+                    code = ErrorMessageType.UNKNOWN_ERROR.code.toString(),
+                    message = ErrorMessageType.UNKNOWN_ERROR.message
+                )
+            )
+        )
+        launch { viewModel.getSurveyQuestions() }.join()
+        assertEquals(expectedUnLoginedErrorState, viewModel.unLoginedErrorState.value)
     }
 
     @Test


### PR DESCRIPTION
@uselessnaming 
뷰모델에서 에러헨들링 코드가 너무 비대하다고 생각해서 core-common 모듈의 ErrorHandleFunctions를 만들어봤습니다.
아직 적용은 feature-hbti모듈의 제가 작업했던 뷰모델만 적용하고 다른 모듈에도 적용할 예정입니다.
호준님이 작업하고 계시는 부분은 호준님께서 우선순위에 맞춰서 점차 적용해주시면 좋을 거 같습니다!

AddAddressViewModel이 수정된 부분은 에러메세지 코드값이 불일치한 거 같아서 수정했습니다.
data계층의 DatastoreImpl에서 반환하는 ResultResponse<T>값들은 모두 errorMessage를 null아니면 ErrorMessage로 줍니다.
그래서 웬만해선 코드값은 하드코딩이 아닌 ErrorMessage의 code속성을 이용해야 실수를 줄일 수 있을 거 같습니다
```kotlin
data class ResultResponse<T>(
    var data: T? = null,
    var errorMessage: ErrorMessage? = null
)
```