### PR TITLE
Test/1.1.4(27) 내부테스트 추가사항

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
         applicationId = "com.hmoa.app"
         minSdk = 26
         targetSdk = 34
-        versionCode = 25
+        versionCode = 27
         versionName = "1.1.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,8 @@
 
     <application
             android:name=".App"
-            android:allowBackup="true"
+            android:allowBackup="false"
+            tools:replace="android:allowBackup, android:roundIcon"
             android:dataExtractionRules="@xml/data_extraction_rules"
             android:fullBackupContent="@xml/backup_rules"
             android:icon="@mipmap/ic_launcher"
@@ -27,7 +28,6 @@
             android:supportsRtl="true"
             android:theme="@style/Theme.Hmoa"
             android:usesCleartextTraffic="true"
-            tools:replace="android:roundIcon"
             tools:targetApi="31">
         <activity
                 android:name=".MainActivity"


### PR DESCRIPTION
@uselessnaming 
내부 테스트 1.1.4(25) 버전 혼선과는 별개로 
앱 삭제 후에도 캐시가 남아있는 문제를 해결할 수 있도록 백업데이터 자동 설정을 true에서 false로 변경했습니다.
분명 예전에 고쳤었는데 최근 merge할 때 없어졌더라구요!
